### PR TITLE
Updates to the ProjectService

### DIFF
--- a/project.go
+++ b/project.go
@@ -25,7 +25,12 @@ type Project struct {
 	Tags               []Tag             `json:"tags,omitempty"`
 	Active             bool              `json:"active"`
 	Metrics            ProjectMetrics    `json:"metrics"`
+	ParentRef          *ParentRef        `json:"parent,omitempty"`
 	LastBOMImport      int               `json:"lastBomImport"`
+}
+
+type ParentRef struct {
+	UUID uuid.UUID `json:"uuid,omitempty"`
 }
 
 type ProjectService struct {

--- a/project.go
+++ b/project.go
@@ -62,6 +62,30 @@ func (ps ProjectService) GetAll(ctx context.Context, po PageOptions) (p Page[Pro
 	return
 }
 
+func (ps ProjectService) GetProjectsForName(ctx context.Context, name string, excludeInactive, onlyRoot bool) (p []Project, err error) {
+	excludeInactiveStr := "false"
+	onlyRootStr := "false"
+	if excludeInactive {
+		excludeInactiveStr = "true"
+	}
+	if onlyRoot {
+		onlyRootStr = "true"
+	}
+	params := map[string]string{
+		"name":            name,
+		"excludeInactive": excludeInactiveStr,
+		"onlyRoot":        onlyRootStr,
+	}
+
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project", withParams(params))
+	if err != nil {
+		return
+	}
+
+	_, err = ps.client.doRequest(req, &p)
+	return
+}
+
 func (ps ProjectService) Create(ctx context.Context, project Project) (p Project, err error) {
 	req, err := ps.client.newRequest(ctx, http.MethodPut, "/api/v1/project", withBody(project))
 	if err != nil {


### PR DESCRIPTION
- Add the ParentRef to a Project - the parent is being returned, but was not in the struct
- Add GetProjectsForName to ProjectService - This is for looking up projects by project name, lookup only works when both name and version are specified.