### PR TITLE
Add GetAllByTag to ProjectService

### DIFF
--- a/client.go
+++ b/client.go
@@ -148,6 +148,16 @@ func withParams(params map[string]string) requestOption {
 	}
 }
 
+func withPathParam(param string) requestOption {
+	return func(req *http.Request) error {
+		if len(param) == 0 {
+			return nil
+		}
+		req.URL.Path = fmt.Sprintf("%s/%s", req.URL.Path, param)
+		return nil
+	}
+}
+
 func withBody(body interface{}) requestOption {
 	return func(req *http.Request) error {
 		if body == nil {

--- a/client.go
+++ b/client.go
@@ -148,12 +148,15 @@ func withParams(params map[string]string) requestOption {
 	}
 }
 
-func withPathParam(param string) requestOption {
+func withPathParams(params map[string]string) requestOption {
 	return func(req *http.Request) error {
-		if len(param) == 0 {
+		if len(params) == 0 {
 			return nil
 		}
-		req.URL.Path = fmt.Sprintf("%s/%s", req.URL.Path, param)
+
+		for k, v := range params {
+			req.URL.Path = strings.Replace(req.URL.Path, fmt.Sprintf("{%s}", k), v, -1)
+		}
 		return nil
 	}
 }

--- a/project.go
+++ b/project.go
@@ -142,7 +142,11 @@ func (ps ProjectService) Lookup(ctx context.Context, name, version string) (p Pr
 }
 
 func (ps ProjectService) GetAllByTag(ctx context.Context, tag string, po PageOptions) (p Page[Project], err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project/tag", withPathParam(tag), withPageOptions(po))
+	params := map[string]string{
+		"tag": tag,
+	}
+
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project/tag/{tag}", withPathParams(params), withPageOptions(po))
 	if err != nil {
 		return
 	}

--- a/project.go
+++ b/project.go
@@ -141,13 +141,18 @@ func (ps ProjectService) Lookup(ctx context.Context, name, version string) (p Pr
 	return
 }
 
-func (ps ProjectService) GetAllByTag(ctx context.Context, tag string) (p []Project, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project/tag", withPathParam(tag))
+func (ps ProjectService) GetAllByTag(ctx context.Context, tag string, po PageOptions) (p Page[Project], err error) {
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project/tag", withPathParam(tag), withPageOptions(po))
 	if err != nil {
 		return
 	}
 
-	_, err = ps.client.doRequest(req, &p)
+	res, err := ps.client.doRequest(req, &p.Items)
+	if err != nil {
+		return
+	}
+
+	p.TotalCount = res.TotalCount
 	return
 }
 

--- a/project.go
+++ b/project.go
@@ -141,6 +141,16 @@ func (ps ProjectService) Lookup(ctx context.Context, name, version string) (p Pr
 	return
 }
 
+func (ps ProjectService) GetAllByTag(ctx context.Context, tag string) (p []Project, err error) {
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project/tag", withPathParam(tag))
+	if err != nil {
+		return
+	}
+
+	_, err = ps.client.doRequest(req, &p)
+	return
+}
+
 type ProjectCloneRequest struct {
 	ProjectUUID         uuid.UUID `json:"project"`
 	Version             string    `json:"version"`


### PR DESCRIPTION
This PR adds:

- `GetAllByTag()` return a list of projects by tag.
