### PR TITLE
Add Create/Delete/Update methods to `PolicyConditionService`

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,6 +41,7 @@ type Client struct {
 	Metrics           MetricsService
 	Permission        PermissionService
 	Policy            PolicyService
+	PolicyCondition   PolicyConditionService
 	PolicyViolation   PolicyViolationService
 	Project           ProjectService
 	ProjectProperty   ProjectPropertyService
@@ -86,6 +87,7 @@ func NewClient(baseURL string, options ...ClientOption) (*Client, error) {
 	client.Metrics = MetricsService{client: &client}
 	client.Permission = PermissionService{client: &client}
 	client.Policy = PolicyService{client: &client}
+	client.PolicyCondition = PolicyConditionService{client: &client}
 	client.PolicyViolation = PolicyViolationService{client: &client}
 	client.Project = ProjectService{client: &client}
 	client.ProjectProperty = ProjectPropertyService{client: &client}

--- a/policy_condition.go
+++ b/policy_condition.go
@@ -9,16 +9,50 @@ import (
 )
 
 type PolicyCondition struct {
-	Policy   *Policy `json:"policy,omitempty"`
-	Operator string  `json:"operator"`
-	Subject  string  `json:"subject"`
-	Value    string  `json:"value"`
 	UUID     uuid.UUID               `json:"uuid,omitempty"`
+	Policy   *Policy                 `json:"policy,omitempty"`
+	Operator PolicyConditionOperator `json:"operator"`
+	Subject  PolicyConditionSubject  `json:"subject"`
+	Value    string                  `json:"value"`
 }
 
 type PolicyConditionService struct {
 	client *Client
 }
+
+type PolicyConditionOperator string
+
+const (
+	PolicyConditionOperatorIs                        PolicyConditionOperator = "IS"
+	PolicyConditionOperatorIsNot                     PolicyConditionOperator = "IS_NOT"
+	PolicyConditionOperatorMatches                   PolicyConditionOperator = "MATCHES"
+	PolicyConditionOperatorNoMatch                   PolicyConditionOperator = "NO_MATCH"
+	PolicyConditionOperatorNumericGreaterThan        PolicyConditionOperator = "NUMERIC_GREATER_THAN"
+	PolicyConditionOperatorNumericLessThan           PolicyConditionOperator = "NUMERIC_LESS_THAN"
+	PolicyConditionOperatorNumericEqual              PolicyConditionOperator = "NUMERIC_EQUAL"
+	PolicyConditionOperatorNumericNotEqual           PolicyConditionOperator = "NUMERIC_NOT_EQUAL"
+	PolicyConditionOperatorNumericGreaterThanOrEqual PolicyConditionOperator = "NUMERIC_GREATER_THAN_OR_EQUAL"
+	PolicyConditionOperatorNumericLesserThanOrEqual  PolicyConditionOperator = "NUMERIC_LESSER_THAN_OR_EQUAL"
+	PolicyConditionOperatorContainsAll               PolicyConditionOperator = "CONTAINS_ALL"
+	PolicyConditionOperatorContainsAny               PolicyConditionOperator = "CONTAINS_ANY"
+)
+
+type PolicyConditionSubject string
+
+const (
+	PolicyConditionSubjectAge             PolicyConditionSubject = "AGE"
+	PolicyConditionSubjectCoordinates     PolicyConditionSubject = "COORDINATES"
+	PolicyConditionSubjectCPE             PolicyConditionSubject = "CPE"
+	PolicyConditionSubjectLicense         PolicyConditionSubject = "LICENSE"
+	PolicyConditionSubjectLicenseGroup    PolicyConditionSubject = "LICENSE_GROUP"
+	PolicyConditionSubjectPackageURL      PolicyConditionSubject = "PACKAGE_URL"
+	PolicyConditionSubjectSeverity        PolicyConditionSubject = "SEVERITY"
+	PolicyConditionSubjectSWIDTagID       PolicyConditionSubject = "SWID_TAGID"
+	PolicyConditionSubjectVersion         PolicyConditionSubject = "VERSION"
+	PolicyConditionSubjectComponentHash   PolicyConditionSubject = "COMPONENT_HASH"
+	PolicyConditionSubjectCWE             PolicyConditionSubject = "CWE"
+	PolicyConditionSubjectVulnerabilityID PolicyConditionSubject = "VULNERABILITY_ID"
+)
 
 func (pcs PolicyConditionService) Create(ctx context.Context, policyUUID uuid.UUID, policyCondition PolicyCondition) (p PolicyCondition, err error) {
 	req, err := pcs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/policy/%s/condition", policyUUID), withBody(policyCondition))

--- a/policy_condition.go
+++ b/policy_condition.go
@@ -1,11 +1,51 @@
 package dtrack
 
-import "github.com/google/uuid"
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+)
 
 type PolicyCondition struct {
-	UUID     uuid.UUID
 	Policy   *Policy `json:"policy,omitempty"`
 	Operator string  `json:"operator"`
 	Subject  string  `json:"subject"`
 	Value    string  `json:"value"`
+	UUID     uuid.UUID               `json:"uuid,omitempty"`
+}
+
+type PolicyConditionService struct {
+	client *Client
+}
+
+func (pcs PolicyConditionService) Create(ctx context.Context, policyUUID uuid.UUID, policyCondition PolicyCondition) (p PolicyCondition, err error) {
+	req, err := pcs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/policy/%s/condition", policyUUID), withBody(policyCondition))
+	if err != nil {
+		return
+	}
+
+	_, err = pcs.client.doRequest(req, &p)
+	return
+}
+
+func (pcs PolicyConditionService) Update(ctx context.Context, policyCondition PolicyCondition) (p PolicyCondition, err error) {
+	req, err := pcs.client.newRequest(ctx, http.MethodPost, "/api/v1/policy/condition", withBody(policyCondition))
+	if err != nil {
+		return
+	}
+
+	_, err = pcs.client.doRequest(req, &p)
+	return
+}
+
+func (pcs PolicyConditionService) Delete(ctx context.Context, policyConditionUUID uuid.UUID) (err error) {
+	req, err := pcs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/policy/condition/%s", policyConditionUUID))
+	if err != nil {
+		return
+	}
+
+	_, err = pcs.client.doRequest(req, nil)
+	return
 }


### PR DESCRIPTION
Hi!

The following implementation was added to `PolicyConditionService`:

- Add Create/Delete/Update
- Add const variable PolicyConditionOperator/PolicyConditionSubject

Confirmation that the following works with local DependencyTrack-v4.8.2:

```golang
import (
	"context"

	dtrack "github.com/DependencyTrack/client-go"
)

func main() {
	ctx := context.Background()
	client, err := dtrack.NewClient("http://localhost:8081", dtrack.WithAPIKey("..."))
	if err != nil {
		panic(err)
	}

	policy, err := client.Policy.Create(ctx, dtrack.Policy{
		Name:           "test",
		Operator:       dtrack.PolicyOperatorAny,
		ViolationState: dtrack.PolicyViolationStateFail,
	})
	if err != nil {
		panic(err)
	}
	fmt.Printf("created policy: %+v\n", policy)

	condition, err := client.PolicyCondition.Create(ctx, policy.UUID, dtrack.PolicyCondition{
		Subject:  dtrack.PolicyConditionSubjectVulnerabilityID,
		Operator: dtrack.PolicyConditionOperatorIs,
		Value:    "CVE-2023-1234",
	})
	if err != nil {
		panic(err)
	}
	fmt.Printf("created condition: %+v\n", condition)

	condition.Value = "CVE-2023-1235"

	conditionUpdated, err := client.PolicyCondition.Update(ctx, condition)
	if err != nil {
		panic(err)
	}
	fmt.Printf("updated condition %s: %+v\n", conditionUpdated.UUID, conditionUpdated.Value)

	if err := client.PolicyCondition.Delete(ctx, conditionUpdated.UUID); err != nil {
		panic(err)
	}
}
```

```
created policy: {UUID:fe07f3c6-6dca-4369-9800-192200d4a9f8 Name:test Operator:ANY ViolationState:INFO PolicyConditions:[] IncludeChildren:false Global:true Projects:[] Tags:[]}
created condition: {UUID:708d0f07-9484-4136-bacf-5b8a003e2917 Policy:<nil> Operator:IS Subject:VULNERABILITY_ID Value:CVE-2023-1234}
updated condition 708d0f07-9484-4136-bacf-5b8a003e2917: CVE-2023-1235
```