### PR TITLE
Added retrieve vulnerability specification by source and id

### DIFF
--- a/vulnerability.go
+++ b/vulnerability.go
@@ -61,12 +61,36 @@ type CWE struct {
 	Name string `json:"name"`
 }
 
+const (
+	SourceTypeNvd      = "NVD"
+	SourceTypeNpm      = "NPM"
+	SourceTypeGithub   = "GITHUB"
+	SourceTypeVulndb   = "VULNDB"
+	SourceTypeOssindex = "OSSINDEX"
+	SourceTypeRetirejs = "RETIREJS"
+	SourceTypeInternal = "INTERNAL"
+	SourceTypeOsv      = "OSV"
+	SourceTypeSnyk     = "SNYK"
+)
+
+type SourceType string
+
 type VulnerabilityService struct {
 	client *Client
 }
 
 func (vs VulnerabilityService) Get(ctx context.Context, vulnUUID uuid.UUID) (v Vulnerability, err error) {
 	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/vulnerability/%s", vulnUUID))
+	if err != nil {
+		return
+	}
+
+	_, err = vs.client.doRequest(req, &v)
+	return
+}
+
+func (vs VulnerabilityService) GetBySource(ctx context.Context, source SourceType, vulnID string) (v Vulnerability, err error) {
+	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/vulnerability/source/%s/vuln/%s", source, vulnID))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The client is missing the Get Vulnerability Specification by source and id. This PR adds such functionality. 