### PR TITLE
feat: add support for `Project.ExternalReferences`

### DIFF
--- a/project.go
+++ b/project.go
@@ -10,24 +10,25 @@ import (
 )
 
 type Project struct {
-	UUID               uuid.UUID         `json:"uuid,omitempty"`
-	Author             string            `json:"author,omitempty"`
-	Publisher          string            `json:"publisher,omitempty"`
-	Group              string            `json:"group,omitempty"`
-	Name               string            `json:"name,omitempty"`
-	Description        string            `json:"description,omitempty"`
-	Version            string            `json:"version,omitempty"`
-	Classifier         string            `json:"classifier,omitempty"`
-	CPE                string            `json:"cpe,omitempty"`
-	PURL               string            `json:"purl,omitempty"`
-	SWIDTagID          string            `json:"swidTagId,omitempty"`
-	DirectDependencies string            `json:"directDependencies,omitempty"`
-	Properties         []ProjectProperty `json:"properties,omitempty"`
-	Tags               []Tag             `json:"tags,omitempty"`
-	Active             bool              `json:"active"`
-	Metrics            ProjectMetrics    `json:"metrics"`
-	ParentRef          *ParentRef        `json:"parent,omitempty"`
-	LastBOMImport      int               `json:"lastBomImport"`
+	UUID               uuid.UUID           `json:"uuid,omitempty"`
+	Author             string              `json:"author,omitempty"`
+	Publisher          string              `json:"publisher,omitempty"`
+	Group              string              `json:"group,omitempty"`
+	Name               string              `json:"name,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	Version            string              `json:"version,omitempty"`
+	Classifier         string              `json:"classifier,omitempty"`
+	CPE                string              `json:"cpe,omitempty"`
+	PURL               string              `json:"purl,omitempty"`
+	SWIDTagID          string              `json:"swidTagId,omitempty"`
+	DirectDependencies string              `json:"directDependencies,omitempty"`
+	Properties         []ProjectProperty   `json:"properties,omitempty"`
+	Tags               []Tag               `json:"tags,omitempty"`
+	Active             bool                `json:"active"`
+	Metrics            ProjectMetrics      `json:"metrics"`
+	ParentRef          *ParentRef          `json:"parent,omitempty"`
+	LastBOMImport      int                 `json:"lastBomImport"`
+	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
 }
 
 type ParentRef struct {


### PR DESCRIPTION
The API includes an externalReferences field in projects, but this is currently ignore by the Go client. This PR adds the field to the type, so it will be captured when deserialised.
