### PR TITLE
feat: support event token response of `Project.Clone`

### DIFF
--- a/about_test.go
+++ b/about_test.go
@@ -2,6 +2,7 @@ package dtrack
 
 import (
 	"context"
+	"fmt"
 	"github.com/google/uuid"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -31,15 +32,21 @@ func TestAboutService_Get(t *testing.T) {
 }
 
 type testContainerOptions struct {
+	Version        string
 	APIPermissions []string
 }
 
 func setUpContainer(t *testing.T, options testContainerOptions) *Client {
 	ctx := context.Background()
 
+	version := "latest"
+	if options.Version != "" {
+		version = options.Version
+	}
+
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: "dependencytrack/apiserver:latest",
+			Image: fmt.Sprintf("dependencytrack/apiserver:%s", version),
 			Env: map[string]string{
 				"JAVA_OPTIONS":                     "-Xmx1g",
 				"SYSTEM_REQUIREMENT_CHECK_ENABLED": "false",

--- a/bom.go
+++ b/bom.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -21,7 +22,7 @@ type BOMUploadRequest struct {
 	ParentUUID     *uuid.UUID `json:"parentUUID,omitempty"`             // Since v4.8.0
 	ParentName     string     `json:"parentName,omitempty"`             // Since v4.8.0
 	ParentVersion  string     `json:"parentVersion,omitempty"`          // Since v4.8.0
-	IsLatest       bool       `json:"isLatestProjectVersion,omitempty"` // Since v4.12.0
+	IsLatest       *bool      `json:"isLatestProjectVersion,omitempty"` // Since v4.12.0
 	AutoCreate     bool       `json:"autoCreate"`
 	BOM            string     `json:"bom"`
 }
@@ -121,8 +122,8 @@ func (bs BOMService) PostBom(ctx context.Context, uploadReq BOMUploadRequest) (t
 		}
 		params["projectTags"] = append(params["projectTags"], strings.Join(tagNames, ","))
 	}
-	if uploadReq.IsLatest {
-		params["isLatest"] = append(params["isLatest"], "true")
+	if uploadReq.IsLatest != nil {
+		params["isLatest"] = append(params["isLatest"], strconv.FormatBool(*uploadReq.IsLatest))
 	}
 	if uploadReq.ParentUUID != nil {
 		params["parentUUID"] = append(params["parentUUID"], uploadReq.ParentUUID.String())

--- a/bom_test.go
+++ b/bom_test.go
@@ -23,7 +23,7 @@ func TestBOMService_Upload(t *testing.T) {
 			{Name: "foo"},
 			{Name: "bar"},
 		},
-		IsLatest:   true,
+		IsLatest:   OptionalBoolOf(true),
 		AutoCreate: true,
 		BOM: base64.StdEncoding.EncodeToString([]byte(`
 {
@@ -39,7 +39,8 @@ func TestBOMService_Upload(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, project.Tags, Tag{Name: "foo"})
 	require.Contains(t, project.Tags, Tag{Name: "bar"})
-	require.True(t, project.IsLatest)
+	require.NotNil(t, project.IsLatest)
+	require.True(t, *project.IsLatest)
 }
 
 func TestBOMService_PostBom(t *testing.T) {
@@ -58,7 +59,7 @@ func TestBOMService_PostBom(t *testing.T) {
 			{Name: "foo"},
 			{Name: "bar"},
 		},
-		IsLatest:   true,
+		IsLatest:   OptionalBoolOf(true),
 		AutoCreate: true,
 		BOM: `
 {
@@ -74,5 +75,6 @@ func TestBOMService_PostBom(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, project.Tags, Tag{Name: "foo"})
 	require.Contains(t, project.Tags, Tag{Name: "bar"})
-	require.True(t, project.IsLatest)
+	require.NotNil(t, project.IsLatest)
+	require.True(t, *project.IsLatest)
 }

--- a/client.go
+++ b/client.go
@@ -124,7 +124,7 @@ func (c Client) isServerVersionAtLeast(targetVersion string) bool {
 	// and doesn't support "-SNAPSHOT" suffixes.
 	targetVersionNormalized := fmt.Sprintf("v%s", targetVersion)
 	actualVersionNormalized := fmt.Sprintf("v%s", strings.TrimSuffix(c.about.Version, "-SNAPSHOT"))
-	return semver.Compare(targetVersionNormalized, actualVersionNormalized) >= 0
+	return semver.Compare(targetVersionNormalized, actualVersionNormalized) <= 0
 }
 
 func (c Client) assertServerVersionAtLeast(targetVersion string) error {

--- a/event.go
+++ b/event.go
@@ -12,6 +12,10 @@ type EventService struct {
 
 type EventToken string
 
+type EventTokenResponse struct {
+	Token EventToken `json:"token"`
+}
+
 type eventProcessingResponse struct {
 	Processing bool `json:"processing"`
 }

--- a/project_test.go
+++ b/project_test.go
@@ -1,0 +1,50 @@
+package dtrack
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestProjectService_Clone(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+		},
+	})
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "acme-app",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+
+	token, err := client.Project.Clone(context.Background(), ProjectCloneRequest{
+		ProjectUUID: project.UUID,
+		Version:     "2.0.0",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+}
+
+func TestProjectService_Clone_v4_10(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		Version: "4.10.1",
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+		},
+	})
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "acme-app",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+
+	token, err := client.Project.Clone(context.Background(), ProjectCloneRequest{
+		ProjectUUID: project.UUID,
+		Version:     "2.0.0",
+	})
+	require.NoError(t, err)
+	require.Empty(t, token)
+}

--- a/util.go
+++ b/util.go
@@ -48,3 +48,11 @@ func ForEach[T any](pageFetchFunc func(po PageOptions) (Page[T], error), handler
 
 	return
 }
+
+func OptionalBoolOf(value bool) *bool {
+	return &value
+}
+
+func OptionalBool() *bool {
+	return nil
+}

--- a/util_test.go
+++ b/util_test.go
@@ -2,6 +2,7 @@ package dtrack
 
 import (
 	"errors"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -102,4 +103,13 @@ func TestForEach_HandlerFuncErr(t *testing.T) {
 	); !errors.Is(err, testErr) {
 		t.Errorf("expected error from handlerFunc but got nil")
 	}
+}
+
+func TestOptionalBoolOf(t *testing.T) {
+	require.True(t, *OptionalBoolOf(true))
+	require.False(t, *OptionalBoolOf(false))
+}
+
+func TestOptionalBool(t *testing.T) {
+	require.Nil(t, OptionalBool())
 }


### PR DESCRIPTION
also fix handling of optional booleans. older server versions fail when fields introduced in newer versions are set.