### PR TITLE
fix: semver comparison

### DIFF
--- a/client.go
+++ b/client.go
@@ -124,7 +124,7 @@ func (c Client) isServerVersionAtLeast(targetVersion string) bool {
 	// and doesn't support "-SNAPSHOT" suffixes.
 	targetVersionNormalized := fmt.Sprintf("v%s", targetVersion)
 	actualVersionNormalized := fmt.Sprintf("v%s", strings.TrimSuffix(c.about.Version, "-SNAPSHOT"))
-	return semver.Compare(targetVersionNormalized, actualVersionNormalized) <= 0
+	return semver.Compare(targetVersionNormalized, actualVersionNormalized) >= 0
 }
 
 func (c Client) assertServerVersionAtLeast(targetVersion string) error {


### PR DESCRIPTION
`isServerVersionAtLeast(targetVersion string)` should return false if `targetVersion` is greater than `client.About.Version` (api server version)

```go
v = "v4.11.0"
w = "v4.12.1"
fmt.Println(semver.Compare(v, w))
-1
 ```
 
> func Compare(v, w [string]) [int]
>
> Compare returns an integer comparing two versions according to semantic version precedence. The result will be 0 if v == w, -1 if v < w, or +1 if v > w. 
> https://pkg.go.dev/golang.org/x/mod/semver#Compare