### PR TITLE
API Key CRUD

### DIFF
--- a/client.go
+++ b/client.go
@@ -209,6 +209,13 @@ func withBody(body interface{}) requestOption {
 				return err
 			}
 			contentType = "application/x-www-form-urlencoded"
+		case string:
+			bodyBuf = new(bytes.Buffer)
+			_, err := io.WriteString(bodyBuf, body)
+			contentType = "text/plain"
+			if err != nil {
+				return err
+			}
 		default:
 			bodyBuf = new(bytes.Buffer)
 			if err := json.NewEncoder(bodyBuf).Encode(body); err != nil {

--- a/team.go
+++ b/team.go
@@ -17,7 +17,11 @@ type Team struct {
 }
 
 type APIKey struct {
-	Key string `json:"key"`
+	Key       string `json:"key"`
+	Comment   string `json:"comment"`
+	Created   int    `json:"created"`
+	LastUsed  int    `json:"lastUsed"`
+	MaskedKey string `json:"maskedKey"`
 }
 
 type TeamService struct {
@@ -59,6 +63,41 @@ func (ts TeamService) GenerateAPIKey(ctx context.Context, teamUUID uuid.UUID) (k
 	_, err = ts.client.doRequest(req, &apiKey)
 	key = apiKey.Key
 	return
+}
+
+func (ts TeamService) DeleteAPIKey(ctx context.Context, key string) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/team/key/%s", key))
+	if err != nil {
+		return
+	}
+	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TeamService) UpdateAPIKeyComment(ctx context.Context, key, comment string) (commentOut string, err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/team/key/%s/comment", key), withBody(comment))
+	if err != nil {
+		return
+	}
+	var apiKey APIKey
+	_, err = ts.client.doRequest(req, &apiKey)
+	commentOut = apiKey.Comment
+	return
+}
+
+func (ts TeamService) GetAPIKeys(ctx context.Context, teamUUID uuid.UUID) (keys []APIKey, err error) {
+	keys = []APIKey{}
+	err = ForEach(
+		func(po PageOptions) (Page[Team], error) { return ts.GetAll(ctx, po) },
+		func(item Team) error {
+			if item.UUID != teamUUID {
+				return nil
+			}
+			keys = append(keys, item.APIKeys...)
+			return nil
+		},
+	)
+	return keys, err
 }
 
 func (ts TeamService) Create(ctx context.Context, team Team) (t Team, err error) {

--- a/team_test.go
+++ b/team_test.go
@@ -1,0 +1,77 @@
+package dtrack
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGenerateAPIKey(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionAccessManagement,
+		},
+	})
+
+	team, err := client.Team.Create(context.Background(), Team{
+		Name: "GenerateAPIKey",
+	})
+	require.NoError(t, err)
+
+	key, err := client.Team.GenerateAPIKey(context.Background(), team.UUID)
+	require.NoError(t, err)
+
+	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
+	require.NoError(t, err)
+	require.Equal(t, len(keys), 1)
+	require.Equal(t, keys[0].Key, key)
+}
+
+func TestDeleteAPIKey(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionAccessManagement,
+		},
+	})
+
+	team, err := client.Team.Create(context.Background(), Team{
+		Name: "DeleteAPIKey",
+	})
+	require.NoError(t, err)
+
+	key, err := client.Team.GenerateAPIKey(context.Background(), team.UUID)
+	require.NoError(t, err)
+
+	err = client.Team.DeleteAPIKey(context.Background(), key)
+	require.NoError(t, err)
+
+	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestUpdateAPIKeyComment(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionAccessManagement,
+		},
+	})
+
+	team, err := client.Team.Create(context.Background(), Team{
+		Name: "UpdateAPIKeyComment",
+	})
+	require.NoError(t, err)
+
+	key, err := client.Team.GenerateAPIKey(context.Background(), team.UUID)
+	require.NoError(t, err)
+
+	comment, err := client.Team.UpdateAPIKeyComment(context.Background(), key, "test-comment")
+	require.NoError(t, err)
+	require.Equal(t, comment, "test-comment")
+
+	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
+	require.NoError(t, err)
+	require.Equal(t, len(keys), 1)
+	require.Equal(t, keys[0].Key, key)
+	require.Equal(t, keys[0].Comment, "test-comment")
+}


### PR DESCRIPTION
## Overview
Add missing `RUD` methods for API Key `CRUD`.

## Detailed

Adds methods to:
- `DeleteAPIKey` - To delete an API key from a Team.
- `UpdateAPIKeyComment` - To set or update the comment associated with an API Key.
- `GetAPIKeys` - To retrieve the API Keys for a Team, since the `TeamService.Get` endpoint does not include them in the API response.

Adds tests to:
- `GenerateAPIKey` with `TestGenerateAPIKey`.
- `DeleteAPIKey` with `TestDeleteAPIKey`.
- `UpdateAPIKeyComment` with `TestUpdateAPIKeyComment`.

Other:
- Adds remaining fields within `APIKey` struct, for the subset of occassions when they are returned.
- Add case within `withBody` to allow for using a `text/plain` `Content-Type` as required by `UpdateAPIKeyComment`.