### PR TITLE
feat: add project field to component struct

### DIFF
--- a/component.go
+++ b/component.go
@@ -41,6 +41,7 @@ type Component struct {
 	DirectDependencies string              `json:"directDependencies,omitempty"`
 	Notes              string              `json:"notes,omitempty"`
 	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
+	ProjectUUID        uuid.UUID           `json:"project.uuid,omitempty"`
 }
 
 type ExternalReference struct {

--- a/component.go
+++ b/component.go
@@ -41,7 +41,7 @@ type Component struct {
 	DirectDependencies string              `json:"directDependencies,omitempty"`
 	Notes              string              `json:"notes,omitempty"`
 	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
-	ProjectUUID        uuid.UUID           `json:"project.uuid,omitempty"`
+	Project            *Project            `json:"project,omitempty"`
 }
 
 type ExternalReference struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rerkcp/client-go
+module github.com/DependencyTrack/client-go
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DependencyTrack/client-go
+module github.com/rerkcp/client-go
 
 go 1.19
 


### PR DESCRIPTION
This is needed to efficiently fix https://github.com/nscuro/dtapac/issues/279

dtapac receives a New Vulnerability found notification via webhook from Dependency Track. This notification includes a component and a list of affected projects. Currently the relevant project for this component can only be found by querying each project and looking for the one that includes the component from the webhook. This is doable, but very inefficient, especially since the component already includes its project, it's just not visible through the go API. This PR makes the project visible in the Component.