### PR TITLE
feat: Add ConfigService to be able to manage ConfigProperty values.

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	Analysis          AnalysisService
 	BOM               BOMService
 	Component         ComponentService
+	Config            ConfigService
 	Finding           FindingService
 	Event             EventService
 	License           LicenseService
@@ -87,6 +88,7 @@ func NewClient(baseURL string, options ...ClientOption) (*Client, error) {
 	client.Analysis = AnalysisService{client: &client}
 	client.BOM = BOMService{client: &client}
 	client.Component = ComponentService{client: &client}
+	client.Config = ConfigService{client: &client}
 	client.Finding = FindingService{client: &client}
 	client.Event = EventService{client: &client}
 	client.License = LicenseService{client: &client}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,64 @@
+package dtrack
+
+import (
+	"context"
+	"net/http"
+)
+
+type ConfigPropertyType string
+
+type ConfigProperty struct {
+	GroupName   string `json:"groupName"`
+	Name        string `json:"propertyName"`
+	Value       string `json:"propertyValue,omitempty"`
+	Type        string `json:"propertyType"`
+	Description string `json:"description,omitempty"`
+}
+
+type ConfigService struct {
+	client *Client
+}
+
+func (cs ConfigService) GetAll(ctx context.Context) (cps []ConfigProperty, err error) {
+	req, err := cs.client.newRequest(ctx, http.MethodGet, "/api/v1/configProperty")
+	if err != nil {
+		return
+	}
+	_, err = cs.client.doRequest(req, &cps)
+	return
+}
+
+func (cs ConfigService) Get(ctx context.Context, groupName, propertyName string) (cp ConfigProperty, err error) {
+	cps, err := cs.GetAll(ctx)
+	if err != nil {
+		return
+	}
+	for _, cp := range cps {
+		if cp.GroupName != groupName {
+			continue
+		}
+		if cp.Name != propertyName {
+			continue
+		}
+		return cp, nil
+	}
+	return
+}
+
+func (cs ConfigService) Update(ctx context.Context, config ConfigProperty) (cp ConfigProperty, err error) {
+	req, err := cs.client.newRequest(ctx, http.MethodPost, "/api/v1/configProperty", withBody(config))
+	if err != nil {
+		return
+	}
+	_, err = cs.client.doRequest(req, &cp)
+	return
+}
+
+func (cs ConfigService) UpdateAll(ctx context.Context, configs []ConfigProperty) (cps []ConfigProperty, err error) {
+	req, err := cs.client.newRequest(ctx, http.MethodPost, "/api/v1/configProperty/aggregate", withBody(configs))
+	if err != nil {
+		return
+	}
+	_, err = cs.client.doRequest(req, &cps)
+	return
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,97 @@
+package dtrack
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+const TEST_URL = "https://localhost"
+
+func TestGetConfigProperty(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionSystemConfiguration,
+		},
+	})
+
+	property, err := client.Config.Get(context.Background(), "general", "base.url")
+	require.NoError(t, err)
+	require.Equal(t, property.GroupName, "general")
+	require.Equal(t, property.Name, "base.url")
+	require.Equal(t, property.Type, "URL")
+	require.Equal(t, property.Description, "URL used to construct links back to Dependency-Track from external systems")
+}
+
+func TestUpdateConfigProperty(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionSystemConfiguration,
+		},
+	})
+
+	property, err := client.Config.Get(context.Background(), "general", "base.url")
+	require.NoError(t, err)
+	require.Empty(t, property.Value)
+
+	property.Value = TEST_URL
+
+	property, err = client.Config.Update(context.Background(), property)
+	require.NoError(t, err)
+	require.Equal(t, property.GroupName, "general")
+	require.Equal(t, property.Name, "base.url")
+	require.Equal(t, property.Type, "URL")
+	require.Equal(t, property.Description, "URL used to construct links back to Dependency-Track from external systems")
+
+	require.Equal(t, property.Value, TEST_URL)
+}
+
+func TestUpdateAllConfigProperty(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionSystemConfiguration,
+		},
+	})
+
+	baseUrl, err := client.Config.Get(context.Background(), "general", "base.url")
+	require.NoError(t, err)
+	badgeEnabled, err := client.Config.Get(context.Background(), "general", "badge.enabled")
+	require.NoError(t, err)
+	defaultLocale, err := client.Config.Get(context.Background(), "general", "default.locale")
+	require.NoError(t, err)
+
+	require.Empty(t, baseUrl.Value)
+	require.Equal(t, badgeEnabled.Value, "false")
+	require.Empty(t, defaultLocale.Value)
+
+	baseUrl.Value = TEST_URL
+	badgeEnabled.Value = "true"
+	defaultLocale.Value = "de"
+
+	cps, err := client.Config.UpdateAll(context.Background(), []ConfigProperty{baseUrl, badgeEnabled, defaultLocale})
+	require.NoError(t, err)
+	require.Equal(t, len(cps), 3)
+	require.Equal(t, cps[0], baseUrl)
+	require.Equal(t, cps[1], badgeEnabled)
+	require.Equal(t, cps[2], defaultLocale)
+}
+
+func TestUnsetConfigProperty(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionSystemConfiguration,
+		},
+	})
+
+	baseUrl, err := client.Config.Get(context.Background(), "general", "base.url")
+	require.NoError(t, err)
+	baseUrl.Value = TEST_URL
+	baseUrl, err = client.Config.Update(context.Background(), baseUrl)
+	require.NoError(t, err)
+	require.Equal(t, baseUrl.Value, TEST_URL)
+
+	baseUrl.Value = ""
+	baseUrl, err = client.Config.Update(context.Background(), baseUrl)
+	require.NoError(t, err)
+	require.Empty(t, baseUrl.Value)
+}


### PR DESCRIPTION
Adds `ConfigService` to manage `ConfigPropertyResource`s.
- Add method for `GetAll`, to retrieve all properties.
- Add method for `Get`, to retrieve a singular value by `groupName` and `propertyName`.
- Add method for `Update`, to update a singular value by `groupName` and `propertyName`.
- Add method for `UpdateAll` to update multiple properties.

Add tests for new methods.