### PR TITLE
fix: Update API Key handling for API v4.13+.

### DIFF
--- a/about_test.go
+++ b/about_test.go
@@ -91,7 +91,7 @@ func setUpContainer(t *testing.T, options testContainerOptions) *Client {
 	apiKey, err := client.Team.GenerateAPIKey(ctx, team.UUID)
 	require.NoError(t, err)
 
-	client, err = NewClient(apiURL, WithAPIKey(apiKey))
+	client, err = NewClient(apiURL, WithAPIKey(apiKey.Key))
 	require.NoError(t, err)
 
 	return client

--- a/team.go
+++ b/team.go
@@ -22,6 +22,8 @@ type APIKey struct {
 	Created   int    `json:"created"`
 	LastUsed  int    `json:"lastUsed"`
 	MaskedKey string `json:"maskedKey"`
+	PublicId  string `json:"publicId"` // Since 4.13
+	Legacy    bool   `json:"legacy"`   // Since 4.13
 }
 
 type TeamService struct {
@@ -53,20 +55,18 @@ func (ts TeamService) GetAll(ctx context.Context, po PageOptions) (p Page[Team],
 	return
 }
 
-func (ts TeamService) GenerateAPIKey(ctx context.Context, teamUUID uuid.UUID) (key string, err error) {
+func (ts TeamService) GenerateAPIKey(ctx context.Context, teamUUID uuid.UUID) (apiKey APIKey, err error) {
 	req, err := ts.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/team/%s/key", teamUUID))
 	if err != nil {
 		return
 	}
 
-	var apiKey APIKey
 	_, err = ts.client.doRequest(req, &apiKey)
-	key = apiKey.Key
 	return
 }
 
-func (ts TeamService) DeleteAPIKey(ctx context.Context, key string) (err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/team/key/%s", key))
+func (ts TeamService) DeleteAPIKey(ctx context.Context, publicIdOrKey string) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/team/key/%s", publicIdOrKey))
 	if err != nil {
 		return
 	}
@@ -74,8 +74,8 @@ func (ts TeamService) DeleteAPIKey(ctx context.Context, key string) (err error) 
 	return
 }
 
-func (ts TeamService) UpdateAPIKeyComment(ctx context.Context, key, comment string) (commentOut string, err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/team/key/%s/comment", key), withBody(comment))
+func (ts TeamService) UpdateAPIKeyComment(ctx context.Context, publicIdOrKey, comment string) (commentOut string, err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/team/key/%s/comment", publicIdOrKey), withBody(comment))
 	if err != nil {
 		return
 	}

--- a/team_test.go
+++ b/team_test.go
@@ -2,9 +2,39 @@ package dtrack
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestGenerateAPIKey_v4_12(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		Version: "4.12.7",
+		APIPermissions: []string{
+			PermissionAccessManagement,
+		},
+	})
+
+	team, err := client.Team.Create(context.Background(), Team{
+		Name: "GenerateAPIKey_v4_12",
+	})
+	require.NoError(t, err)
+
+	key, err := client.Team.GenerateAPIKey(context.Background(), team.UUID)
+	require.NoError(t, err)
+
+	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
+	require.NoError(t, err)
+	require.Equal(t, len(keys), 1)
+	require.Equal(t, keys[0].Key, key.Key)
+	require.Equal(t, keys[0].MaskedKey, key.MaskedKey)
+	require.Equal(t, keys[0].Comment, "")
+	require.Equal(t, key.Comment, "")
+	require.Equal(t, keys[0].Created, key.Created)
+	require.Equal(t, len(key.Key), 36)
+	require.Equal(t, len(key.MaskedKey), 36)
+}
 
 func TestGenerateAPIKey(t *testing.T) {
 	client := setUpContainer(t, testContainerOptions{
@@ -24,7 +54,42 @@ func TestGenerateAPIKey(t *testing.T) {
 	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
 	require.NoError(t, err)
 	require.Equal(t, len(keys), 1)
-	require.Equal(t, keys[0].Key, key)
+	require.Equal(t, keys[0].PublicId, key.PublicId)
+	require.Equal(t, keys[0].Comment, key.Comment)
+	require.Equal(t, keys[0].Created, key.Created)
+	require.Equal(t, keys[0].MaskedKey, key.MaskedKey)
+	require.Equal(t, keys[0].Key, "")
+	require.Equal(t, keys[0].Legacy, false)
+	require.Equal(t, len(keys[0].PublicId), 8)
+	require.Equal(t, keys[0].MaskedKey, "odt_"+key.PublicId+strings.Repeat("*", 32))
+}
+
+func TestDeleteAPIKey_v4_12(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		Version: "4.12.7",
+		APIPermissions: []string{
+			PermissionAccessManagement,
+		},
+	})
+
+	team, err := client.Team.Create(context.Background(), Team{
+		Name: "DeleteAPIKey_v4_12",
+	})
+	require.NoError(t, err)
+
+	key, err := client.Team.GenerateAPIKey(context.Background(), team.UUID)
+	require.NoError(t, err)
+
+	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
+	require.NoError(t, err)
+	require.Equal(t, len(keys), 1)
+
+	err = client.Team.DeleteAPIKey(context.Background(), key.Key)
+	require.NoError(t, err)
+
+	keys, err = client.Team.GetAPIKeys(context.Background(), team.UUID)
+	require.NoError(t, err)
+	require.Empty(t, keys)
 }
 
 func TestDeleteAPIKey(t *testing.T) {
@@ -42,12 +107,44 @@ func TestDeleteAPIKey(t *testing.T) {
 	key, err := client.Team.GenerateAPIKey(context.Background(), team.UUID)
 	require.NoError(t, err)
 
-	err = client.Team.DeleteAPIKey(context.Background(), key)
+	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
 	require.NoError(t, err)
+	require.Equal(t, len(keys), 1)
+
+	err = client.Team.DeleteAPIKey(context.Background(), key.PublicId)
+	require.NoError(t, err)
+
+	keys, err = client.Team.GetAPIKeys(context.Background(), team.UUID)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestUpdateAPIKeyComment_v4_12(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		Version: "4.12.7",
+		APIPermissions: []string{
+			PermissionAccessManagement,
+		},
+	})
+
+	team, err := client.Team.Create(context.Background(), Team{
+		Name: "UpdateAPIKeyComment_v4_12",
+	})
+	require.NoError(t, err)
+
+	key, err := client.Team.GenerateAPIKey(context.Background(), team.UUID)
+	require.NoError(t, err)
+	require.Equal(t, key.Comment, "")
+
+	comment, err := client.Team.UpdateAPIKeyComment(context.Background(), key.Key, "test-comment")
+	require.NoError(t, err)
+	require.Equal(t, comment, "test-comment")
 
 	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
 	require.NoError(t, err)
-	require.Empty(t, keys)
+	require.Equal(t, len(keys), 1)
+	require.Equal(t, keys[0].Key, key.Key)
+	require.Equal(t, keys[0].Comment, "test-comment")
 }
 
 func TestUpdateAPIKeyComment(t *testing.T) {
@@ -64,14 +161,15 @@ func TestUpdateAPIKeyComment(t *testing.T) {
 
 	key, err := client.Team.GenerateAPIKey(context.Background(), team.UUID)
 	require.NoError(t, err)
+	require.Equal(t, key.Comment, "")
 
-	comment, err := client.Team.UpdateAPIKeyComment(context.Background(), key, "test-comment")
+	comment, err := client.Team.UpdateAPIKeyComment(context.Background(), key.PublicId, "test-comment")
 	require.NoError(t, err)
 	require.Equal(t, comment, "test-comment")
 
 	keys, err := client.Team.GetAPIKeys(context.Background(), team.UUID)
 	require.NoError(t, err)
 	require.Equal(t, len(keys), 1)
-	require.Equal(t, keys[0].Key, key)
+	require.Equal(t, keys[0].PublicId, key.PublicId)
 	require.Equal(t, keys[0].Comment, "test-comment")
 }


### PR DESCRIPTION
- Update function signatures for `TeamService` to use `publicIdOrKey` as used within API from `v4.13`.
- Modify `TeamService.CreateAPIKey` to return `APIKey` instead of `string`, allowing for access to `PublicId`, to be used for later requests.
- Add new fields `PublicId`, `Legacy` to `APIKey`, as introduced in API `v4.13`.
- Split API Key tests between those pre-4.13, which use `key` in requests, and those post `4.13`, which use `publicId`.