### PR TITLE
feat: Add TagService

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,6 +54,7 @@ type Client struct {
 	Project           ProjectService
 	ProjectProperty   ProjectPropertyService
 	Repository        RepositoryService
+	Tag               TagService
 	Team              TeamService
 	User              UserService
 	VEX               VEXService
@@ -105,6 +106,7 @@ func NewClient(baseURL string, options ...ClientOption) (*Client, error) {
 	client.Project = ProjectService{client: &client}
 	client.ProjectProperty = ProjectPropertyService{client: &client}
 	client.Repository = RepositoryService{client: &client}
+	client.Tag = TagService{client: &client}
 	client.Team = TeamService{client: &client}
 	client.User = UserService{client: &client}
 	client.VEX = VEXService{client: &client}
@@ -283,6 +285,27 @@ func withPageOptions(po PageOptions) requestOption {
 
 		if po.PageSize > 0 {
 			query.Set("pageSize", strconv.Itoa(po.PageSize))
+		}
+
+		req.URL.RawQuery = query.Encode()
+
+		return nil
+	}
+}
+
+type SortOptions struct {
+	Name  string `json:"sortName"`
+	Order string `json:"sortOrder"`
+}
+
+func withSortOptions(so SortOptions) requestOption {
+	return func(req *http.Request) error {
+		query := req.URL.Query()
+		if len(so.Name) > 0 {
+			query.Set("sortName", so.Name)
+		}
+		if len(so.Order) > 0 {
+			query.Set("sortOrder", so.Order)
 		}
 
 		req.URL.RawQuery = query.Encode()

--- a/tag.go
+++ b/tag.go
@@ -1,5 +1,56 @@
 package dtrack
 
+import (
+	"context"
+	"net/http"
+)
+
 type Tag struct {
 	Name string `json:"name"`
+}
+
+type TagService struct {
+	client *Client
+}
+
+type TagListResponseItem struct {
+	Name                  string `json:"name,omitempty"`
+	ProjectCount          int64  `json:"projectCount,omitempty"`
+	PolicyCount           int64  `json:"policyCount,omitempty"`
+	NotificationRuleCount int64  `json:"notificationRuleCount,omitempty"`
+}
+
+func (ts TagService) Create(ctx context.Context, names []string) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodPut, "/api/v1/tag", withBody(names))
+	if err != nil {
+		return
+	}
+
+	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TagService) GetAll(ctx context.Context, po PageOptions, so SortOptions) (p Page[TagListResponseItem], err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodGet, "/api/v1/tag", withPageOptions(po), withSortOptions(so))
+	if err != nil {
+		return
+	}
+
+	res, err := ts.client.doRequest(req, &p.Items)
+	if err != nil {
+		return
+	}
+
+	p.TotalCount = res.TotalCount
+	return
+}
+
+func (ts TagService) Delete(ctx context.Context, names []string) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, "/api/v1/tag", withBody(names))
+	if err != nil {
+		return
+	}
+
+	_, err = ts.client.doRequest(req, nil)
+	return
 }

--- a/tag.go
+++ b/tag.go
@@ -23,6 +23,17 @@ type TagListResponseItem struct {
 	NotificationRuleCount int64  `json:"notificationRuleCount,omitempty"`
 }
 
+type TaggedProjectListResponseItem struct {
+	UUID    uuid.UUID `json:"uuid,omitempty"`
+	Name    string    `json:"name,omitempty"`
+	Version string    `json:"version,omitempty"`
+}
+
+type TaggedPolicyListResponseItem struct {
+	UUID uuid.UUID `json:"uuid,omitempty"`
+	Name string    `json:"name,omitempty"`
+}
+
 func (ts TagService) Create(ctx context.Context, names []string) (err error) {
 	req, err := ts.client.newRequest(ctx, http.MethodPut, "/api/v1/tag", withBody(names))
 	if err != nil {
@@ -59,10 +70,100 @@ func (ts TagService) Delete(ctx context.Context, names []string) (err error) {
 }
 
 func (ts TagService) TagProjects(ctx context.Context, tag string, projects []uuid.UUID) (err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/%s/project", tag), withBody(Map(projects, uuid.UUID.String)))
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/tag/%s/project", tag), withBody(projects))
 	if err != nil {
 		return
 	}
 	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TagService) UntagProjects(ctx context.Context, tag string, projects []uuid.UUID) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/tag/%s/project", tag), withBody(projects))
+	if err != nil {
+		return
+	}
+	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TagService) GetProjects(ctx context.Context, tag string, po PageOptions, so SortOptions) (p Page[TaggedProjectListResponseItem], err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/tag/%s/project", tag), withPageOptions(po), withSortOptions(so))
+	if err != nil {
+		return
+	}
+
+	res, err := ts.client.doRequest(req, &p.Items)
+	if err != nil {
+		return
+	}
+
+	p.TotalCount = res.TotalCount
+	return
+}
+
+func (ts TagService) TagPolicies(ctx context.Context, tag string, policies []uuid.UUID) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/tag/%s/policy", tag), withBody(policies))
+	if err != nil {
+		return
+	}
+	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TagService) UntagPolicies(ctx context.Context, tag string, policies []uuid.UUID) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/tag/%s/policy", tag), withBody(policies))
+	if err != nil {
+		return
+	}
+	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TagService) GetPolicies(ctx context.Context, tag string, po PageOptions, so SortOptions) (p Page[TaggedPolicyListResponseItem], err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/tag/%s/policy", tag), withPageOptions(po), withSortOptions(so))
+	if err != nil {
+		return
+	}
+
+	res, err := ts.client.doRequest(req, &p.Items)
+	if err != nil {
+		return
+	}
+
+	p.TotalCount = res.TotalCount
+	return
+}
+
+func (ts TagService) TagNotificationRules(ctx context.Context, tag string, rules []uuid.UUID) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/tag/%s/notificationRule", tag), withBody(rules))
+	if err != nil {
+		return
+	}
+	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TagService) UntagNotificationRules(ctx context.Context, tag string, rules []uuid.UUID) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/tag/%s/notificationRule", tag), withBody(rules))
+	if err != nil {
+		return
+	}
+	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TagService) GetNotificationRules(ctx context.Context, tag string, po PageOptions, so SortOptions) (p Page[TaggedPolicyListResponseItem], err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/tag/%s/notificationRule", tag), withPageOptions(po), withSortOptions(so))
+	if err != nil {
+		return
+	}
+
+	res, err := ts.client.doRequest(req, &p.Items)
+	if err != nil {
+		return
+	}
+
+	p.TotalCount = res.TotalCount
 	return
 }

--- a/tag.go
+++ b/tag.go
@@ -2,7 +2,10 @@ package dtrack
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+
+	"github.com/google/uuid"
 )
 
 type Tag struct {
@@ -51,6 +54,15 @@ func (ts TagService) Delete(ctx context.Context, names []string) (err error) {
 		return
 	}
 
+	_, err = ts.client.doRequest(req, nil)
+	return
+}
+
+func (ts TagService) TagProjects(ctx context.Context, tag string, projects []uuid.UUID) (err error) {
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/%s/project", tag), withBody(Map(projects, uuid.UUID.String)))
+	if err != nil {
+		return
+	}
 	_, err = ts.client.doRequest(req, nil)
 	return
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,42 @@
+package dtrack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTag(t *testing.T) {
+	po := PageOptions{
+		PageSize: 10,
+	}
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionTagManagement,
+			PermissionViewPortfolio,
+		},
+	})
+
+	tags, err := client.Tag.GetAll(context.Background(), po, SortOptions{})
+	require.NoError(t, err)
+	require.Equal(t, tags.TotalCount, 0)
+	require.Empty(t, tags.Items)
+
+	err = client.Tag.Create(context.Background(), []string{"test_foo", "test_bar"})
+	require.NoError(t, err)
+
+	tags, err = client.Tag.GetAll(context.Background(), po, SortOptions{})
+	require.NoError(t, err)
+	require.Equal(t, tags.TotalCount, 2)
+	require.Equal(t, tags.Items[0].Name, "test_bar")
+	require.Equal(t, tags.Items[1].Name, "test_foo")
+
+	err = client.Tag.Delete(context.Background(), []string{"test_bar", "test_foo"})
+	require.NoError(t, err)
+
+	tags, err = client.Tag.GetAll(context.Background(), po, SortOptions{})
+	require.NoError(t, err)
+	require.Equal(t, tags.TotalCount, 0)
+	require.Empty(t, tags.Items)
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -31,6 +31,9 @@ func TestTag(t *testing.T) {
 	require.Equal(t, tags.TotalCount, 2)
 	require.Equal(t, tags.Items[0].Name, "test_bar")
 	require.Equal(t, tags.Items[1].Name, "test_foo")
+	require.Equal(t, tags.Items[0].NotificationRuleCount, 0)
+	require.Equal(t, tags.Items[0].PolicyCount, 0)
+	require.Equal(t, tags.Items[0].ProjectCount, 0)
 
 	err = client.Tag.Delete(context.Background(), []string{"test_bar", "test_foo"})
 	require.NoError(t, err)
@@ -39,4 +42,51 @@ func TestTag(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tags.TotalCount, 0)
 	require.Empty(t, tags.Items)
+}
+
+func TestTagCounts(t *testing.T) {
+	po := PageOptions{PageSize: 10}
+	tag := Tag{Name: "test_tag"}
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionTagManagement,
+			PermissionViewPortfolio,
+			PermissionPortfolioManagement,
+			PermissionPolicyManagement,
+		},
+	})
+
+	tags, err := client.Tag.GetAll(context.Background(), po, SortOptions{})
+	require.NoError(t, err)
+	require.Equal(t, tags.TotalCount, 0)
+	require.Empty(t, tags.Items)
+
+	err = client.Tag.Create(context.Background(), []string{tag.Name})
+	require.NoError(t, err)
+
+	// Setup Project
+	project, err := client.Project.Create(context.Background(), Project{
+		Name: "test_project",
+		Tags: []Tag{tag},
+	})
+	require.NoError(t, err)
+	require.Equal(t, len(project.Tags), 1)
+
+	// Setup Policy
+	policy, err := client.Policy.Create(context.Background(), Policy{
+		Name:           "test_policy",
+		Operator:       PolicyOperatorAll,
+		ViolationState: PolicyViolationStateFail,
+	})
+	require.NoError(t, err)
+	_, err = client.Policy.AddTag(context.Background(), policy.UUID, tag.Name)
+	require.NoError(t, err)
+
+	// Count assertions
+	tags, err = client.Tag.GetAll(context.Background(), po, SortOptions{})
+	require.NoError(t, err)
+	require.Equal(t, tags.TotalCount, 1)
+	require.Equal(t, tags.Items[0].NotificationRuleCount, int64(0))
+	require.Equal(t, tags.Items[0].PolicyCount, int64(1))
+	require.Equal(t, tags.Items[0].ProjectCount, int64(1))
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,4 +90,53 @@ func TestTagCounts(t *testing.T) {
 	require.Equal(t, tags.Items[0].NotificationRuleCount, int64(0))
 	require.Equal(t, tags.Items[0].PolicyCount, int64(1))
 	require.Equal(t, tags.Items[0].ProjectCount, int64(1))
+}
+
+func TestTagProject(t *testing.T) {
+	po := PageOptions{PageSize: 10}
+	tag := Tag{Name: "test_tag_project"}
+	projectName := "test_project"
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionTagManagement,
+			PermissionPortfolioManagement,
+			PermissionViewPortfolio,
+		},
+	})
+
+	// Setup
+	err := client.Tag.Create(context.Background(), []string{tag.Name})
+	require.NoError(t, err)
+
+	project, err := client.Project.Create(context.Background(), Project{Name: projectName})
+	require.NoError(t, err)
+	require.Equal(t, project.Name, projectName)
+
+	// Baseline
+	projects, err := client.Tag.GetProjects(context.Background(), tag.Name, po, SortOptions{})
+	require.NoError(t, err)
+	require.Equal(t, projects.TotalCount, 0)
+	require.Empty(t, projects.Items)
+
+	// Tag
+	err = client.Tag.TagProjects(context.Background(), tag.Name, []uuid.UUID{project.UUID})
+	require.NoError(t, err)
+
+	// Check Presence
+	projects, err = client.Tag.GetProjects(context.Background(), tag.Name, po, SortOptions{})
+	require.NoError(t, err)
+	require.Equal(t, projects.TotalCount, 1)
+	require.Equal(t, projects.Items[0].UUID, project.UUID)
+	require.Equal(t, projects.Items[0].Name, project.Name)
+	require.Equal(t, projects.Items[0].Version, project.Version)
+
+	// Untag
+	err = client.Tag.UntagProjects(context.Background(), tag.Name, []uuid.UUID{project.UUID})
+	require.NoError(t, err)
+
+	// Check Absence
+	projects, err = client.Tag.GetProjects(context.Background(), tag.Name, po, SortOptions{})
+	require.NoError(t, err)
+	require.Equal(t, projects.TotalCount, 0)
+	require.Empty(t, projects.Items)
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -32,9 +32,9 @@ func TestTag(t *testing.T) {
 	require.Equal(t, tags.TotalCount, 2)
 	require.Equal(t, tags.Items[0].Name, "test_bar")
 	require.Equal(t, tags.Items[1].Name, "test_foo")
-	require.Equal(t, tags.Items[0].NotificationRuleCount, 0)
-	require.Equal(t, tags.Items[0].PolicyCount, 0)
-	require.Equal(t, tags.Items[0].ProjectCount, 0)
+	require.Equal(t, tags.Items[0].NotificationRuleCount, int64(0))
+	require.Equal(t, tags.Items[0].PolicyCount, int64(0))
+	require.Equal(t, tags.Items[0].ProjectCount, int64(0))
 
 	err = client.Tag.Delete(context.Background(), []string{"test_bar", "test_foo"})
 	require.NoError(t, err)

--- a/util.go
+++ b/util.go
@@ -49,6 +49,14 @@ func ForEach[T any](pageFetchFunc func(po PageOptions) (Page[T], error), handler
 	return
 }
 
+func Map[T, U any](items []T, transformer func(item T) U) (output []U) {
+	output = []U{}
+	for _, t := range items {
+		output = append(output, transformer(t))
+	}
+	return
+}
+
 func OptionalBoolOf(value bool) *bool {
 	return &value
 }

--- a/util.go
+++ b/util.go
@@ -49,14 +49,6 @@ func ForEach[T any](pageFetchFunc func(po PageOptions) (Page[T], error), handler
 	return
 }
 
-func Map[T, U any](items []T, transformer func(item T) U) (output []U) {
-	output = []U{}
-	for _, t := range items {
-		output = append(output, transformer(t))
-	}
-	return
-}
-
 func OptionalBoolOf(value bool) *bool {
 	return &value
 }


### PR DESCRIPTION
- Add `TagService` to be able to create, and delete tags.
- Provide bulk operations to be able tag and untag projects, policies and notification rules.
- Add tests for bulk operations of projects, policies.
  - Not added for notification rules, as they are not managed within SDK at present. 