### PR TITLE
feat: Add repoMeta to Component type and allow component filtering

### DIFF
--- a/component.go
+++ b/component.go
@@ -3,45 +3,45 @@ package dtrack
 import (
 	"context"
 	"fmt"
-	"net/http"
-
 	"github.com/google/uuid"
+	"net/http"
 )
 
 type Component struct {
-	UUID               uuid.UUID           `json:"uuid,omitempty"`
-	Author             string              `json:"author,omitempty"`
-	Publisher          string              `json:"publisher,omitempty"`
-	Group              string              `json:"group,omitempty"`
-	Name               string              `json:"name"`
-	Version            string              `json:"version"`
-	Classifier         string              `json:"classifier,omitempty"`
-	FileName           string              `json:"filename,omitempty"`
-	Extension          string              `json:"extension,omitempty"`
-	MD5                string              `json:"md5,omitempty"`
-	SHA1               string              `json:"sha1,omitempty"`
-	SHA256             string              `json:"sha256,omitempty"`
-	SHA384             string              `json:"sha384,omitempty"`
-	SHA512             string              `json:"sha512,omitempty"`
-	SHA3_256           string              `json:"sha3_256,omitempty"`
-	SHA3_384           string              `json:"sha3_384,omitempty"`
-	SHA3_512           string              `json:"sha3_512,omitempty"`
-	BLAKE2b_256        string              `json:"blake2b_256,omitempty"`
-	BLAKE2b_384        string              `json:"blake2b_384,omitempty"`
-	BLAKE2b_512        string              `json:"blake2b_512,omitempty"`
-	BLAKE3             string              `json:"blake3,omitempty"`
-	CPE                string              `json:"cpe,omitempty"`
-	PURL               string              `json:"purl,omitempty"`
-	SWIDTagID          string              `json:"swidTagId,omitempty"`
-	Internal           bool                `json:"isInternal,omitempty"`
-	Description        string              `json:"description,omitempty"`
-	Copyright          string              `json:"copyright,omitempty"`
-	License            string              `json:"license,omitempty"`
-	ResolvedLicense    *License            `json:"resolvedLicense,omitempty"`
-	DirectDependencies string              `json:"directDependencies,omitempty"`
-	Notes              string              `json:"notes,omitempty"`
-	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
-	Project            *Project            `json:"project,omitempty"`
+	UUID               uuid.UUID                `json:"uuid,omitempty"`
+	Author             string                   `json:"author,omitempty"`
+	Publisher          string                   `json:"publisher,omitempty"`
+	Group              string                   `json:"group,omitempty"`
+	Name               string                   `json:"name"`
+	Version            string                   `json:"version"`
+	Classifier         string                   `json:"classifier,omitempty"`
+	FileName           string                   `json:"filename,omitempty"`
+	Extension          string                   `json:"extension,omitempty"`
+	MD5                string                   `json:"md5,omitempty"`
+	SHA1               string                   `json:"sha1,omitempty"`
+	SHA256             string                   `json:"sha256,omitempty"`
+	SHA384             string                   `json:"sha384,omitempty"`
+	SHA512             string                   `json:"sha512,omitempty"`
+	SHA3_256           string                   `json:"sha3_256,omitempty"`
+	SHA3_384           string                   `json:"sha3_384,omitempty"`
+	SHA3_512           string                   `json:"sha3_512,omitempty"`
+	BLAKE2b_256        string                   `json:"blake2b_256,omitempty"`
+	BLAKE2b_384        string                   `json:"blake2b_384,omitempty"`
+	BLAKE2b_512        string                   `json:"blake2b_512,omitempty"`
+	BLAKE3             string                   `json:"blake3,omitempty"`
+	CPE                string                   `json:"cpe,omitempty"`
+	PURL               string                   `json:"purl,omitempty"`
+	SWIDTagID          string                   `json:"swidTagId,omitempty"`
+	Internal           bool                     `json:"isInternal,omitempty"`
+	Description        string                   `json:"description,omitempty"`
+	Copyright          string                   `json:"copyright,omitempty"`
+	License            string                   `json:"license,omitempty"`
+	ResolvedLicense    *License                 `json:"resolvedLicense,omitempty"`
+	DirectDependencies string                   `json:"directDependencies,omitempty"`
+	Notes              string                   `json:"notes,omitempty"`
+	ExternalReferences []ExternalReference      `json:"externalReferences,omitempty"`
+	Project            *Project                 `json:"project,omitempty"`
+	RepositoryMeta     *RepositoryMetaComponent `json:"repositoryMeta,omitempty"`
 }
 
 type ExternalReference struct {
@@ -54,6 +54,11 @@ type ComponentService struct {
 	client *Client
 }
 
+type ComponentFilterOptions struct {
+	OnlyOutdated bool
+	OnlyDirect   bool
+}
+
 func (cs ComponentService) Get(ctx context.Context, componentUUID uuid.UUID) (c Component, err error) {
 	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/%s", componentUUID))
 	if err != nil {
@@ -64,8 +69,8 @@ func (cs ComponentService) Get(ctx context.Context, componentUUID uuid.UUID) (c 
 	return
 }
 
-func (cs ComponentService) GetAll(ctx context.Context, projectUUID uuid.UUID, po PageOptions) (p Page[Component], err error) {
-	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/project/%s", projectUUID), withPageOptions(po))
+func (cs ComponentService) GetAll(ctx context.Context, projectUUID uuid.UUID, po PageOptions, filterOptions ...ComponentFilterOptions) (p Page[Component], err error) {
+	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/project/%s", projectUUID), withPageOptions(po), withComponentFilterOptions(filterOptions))
 	if err != nil {
 		return
 	}
@@ -77,6 +82,25 @@ func (cs ComponentService) GetAll(ctx context.Context, projectUUID uuid.UUID, po
 
 	p.TotalCount = res.TotalCount
 	return
+}
+
+func withComponentFilterOptions(filterOptions []ComponentFilterOptions) requestOption {
+	return func(req *http.Request) error {
+		if len(filterOptions) == 0 {
+			return nil
+		}
+
+		query := req.URL.Query()
+		if filterOptions[0].OnlyDirect {
+			query.Set("onlyDirect", "true")
+		}
+		if filterOptions[0].OnlyOutdated {
+			query.Set("onlyOutdated", "true")
+		}
+
+		req.URL.RawQuery = query.Encode()
+		return nil
+	}
 }
 
 func (cs ComponentService) Create(ctx context.Context, projectUUID string, component Component) (c Component, err error) {

--- a/repository.go
+++ b/repository.go
@@ -39,7 +39,12 @@ type Repository struct {
 }
 
 type RepositoryMetaComponent struct {
-	LatestVersion string `json:"latestVersion"`
+	RepositoryType string `json:"repositoryType"`
+	Namespace      string `json:"namespace,omitempty"`
+	Name           string `json:"name"`
+	LatestVersion  string `json:"latestVersion"`
+	Published      int    `json:"published"`
+	LastCheck      int    `json:"lastCheck"`
 }
 
 type RepositoryService struct {


### PR DESCRIPTION
I'm about to extract some "tech debt" or "project health" kind of metrics from dtrack and need to fetch outdated dependencies of projects.

No idea if that's the way to change the API (in a compatible manner), just guide me in the right direction.