### PR TITLE
feat: ComponentService bindings

### DIFF
--- a/component.go
+++ b/component.go
@@ -127,7 +127,7 @@ func withComponentFilterOptions(filterOptions ComponentFilterOptions) requestOpt
 	}
 }
 
-func (cs ComponentService) Create(ctx context.Context, projectUUID string, component Component) (c Component, err error) {
+func (cs ComponentService) Create(ctx context.Context, projectUUID uuid.UUID, component Component) (c Component, err error) {
 	err = cs.client.assertServerVersionAtLeast("3.0.0")
 	if err != nil {
 		return
@@ -172,7 +172,7 @@ func (cs ComponentService) Delete(ctx context.Context, componentUUID uuid.UUID) 
 	return
 }
 
-func (cs ComponentService) GetProperties(ctx context.Context, componentUUID uuid.UUID) (p ComponentProperty, err error) {
+func (cs ComponentService) GetProperties(ctx context.Context, componentUUID uuid.UUID) (ps []ComponentProperty, err error) {
 	err = cs.client.assertServerVersionAtLeast("4.11.0")
 	if err != nil {
 		return
@@ -183,7 +183,7 @@ func (cs ComponentService) GetProperties(ctx context.Context, componentUUID uuid
 		return
 	}
 
-	_, err = cs.client.doRequest(req, &p)
+	_, err = cs.client.doRequest(req, &ps)
 	return
 }
 

--- a/component.go
+++ b/component.go
@@ -59,7 +59,31 @@ type ComponentFilterOptions struct {
 	OnlyDirect   bool
 }
 
+type ComponentProperty struct {
+	Group       string    `json:"groupName,omitempty"`
+	Name        string    `json:"propertyName,omitempty"`
+	Value       string    `json:"propertyValue,omitempty"`
+	Type        string    `json:"propertyType"`
+	Description string    `json:"description,omitempty"`
+	UUID        uuid.UUID `json:"uuid"`
+}
+
+type ComponentIdentityQueryOptions struct {
+	Group     string
+	Name      string
+	Version   string
+	PURL      string
+	CPE       string
+	SWIDTagID string
+	Project   uuid.UUID
+}
+
 func (cs ComponentService) Get(ctx context.Context, componentUUID uuid.UUID) (c Component, err error) {
+	err = cs.client.assertServerVersionAtLeast("3.0.0")
+	if err != nil {
+		return
+	}
+
 	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/%s", componentUUID))
 	if err != nil {
 		return
@@ -70,6 +94,11 @@ func (cs ComponentService) Get(ctx context.Context, componentUUID uuid.UUID) (c 
 }
 
 func (cs ComponentService) GetAll(ctx context.Context, projectUUID uuid.UUID, po PageOptions, filterOptions ComponentFilterOptions) (p Page[Component], err error) {
+	err = cs.client.assertServerVersionAtLeast("4.0.0")
+	if err != nil {
+		return
+	}
+
 	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/project/%s", projectUUID), withPageOptions(po), withComponentFilterOptions(filterOptions))
 	if err != nil {
 		return
@@ -99,9 +128,12 @@ func withComponentFilterOptions(filterOptions ComponentFilterOptions) requestOpt
 }
 
 func (cs ComponentService) Create(ctx context.Context, projectUUID string, component Component) (c Component, err error) {
-	req, err := cs.client.newRequest(ctx, http.MethodPut,
-		fmt.Sprintf("/api/v1/component/project/%s", projectUUID),
-		withBody(component))
+	err = cs.client.assertServerVersionAtLeast("3.0.0")
+	if err != nil {
+		return
+	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/component/project/%s", projectUUID), withBody(component))
 	if err != nil {
 		return
 	}
@@ -111,12 +143,164 @@ func (cs ComponentService) Create(ctx context.Context, projectUUID string, compo
 }
 
 func (cs ComponentService) Update(ctx context.Context, component Component) (c Component, err error) {
-	req, err := cs.client.newRequest(ctx, http.MethodPost,
-		"/api/v1/component",
-		withBody(component))
+	err = cs.client.assertServerVersionAtLeast("3.0.0")
 	if err != nil {
 		return
 	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodPost, "/api/v1/component", withBody(component))
+	if err != nil {
+		return
+	}
+
 	_, err = cs.client.doRequest(req, &c)
+	return
+}
+
+func (cs ComponentService) Delete(ctx context.Context, componentUUID uuid.UUID) (err error) {
+	err = cs.client.assertServerVersionAtLeast("3.3.0")
+	if err != nil {
+		return
+	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/component/%s", componentUUID))
+	if err != nil {
+		return
+	}
+
+	_, err = cs.client.doRequest(req, nil)
+	return
+}
+
+func (cs ComponentService) GetProperties(ctx context.Context, componentUUID uuid.UUID) (p ComponentProperty, err error) {
+	err = cs.client.assertServerVersionAtLeast("4.11.0")
+	if err != nil {
+		return
+	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/%s/property", componentUUID))
+	if err != nil {
+		return
+	}
+
+	_, err = cs.client.doRequest(req, &p)
+	return
+}
+
+func (cs ComponentService) CreateProperty(ctx context.Context, componentUUID uuid.UUID, property ComponentProperty) (p ComponentProperty, err error) {
+	err = cs.client.assertServerVersionAtLeast("4.11.0")
+	if err != nil {
+		return
+	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/component/%s/property", componentUUID), withBody(property))
+	if err != nil {
+		return
+	}
+
+	_, err = cs.client.doRequest(req, &p)
+	return
+}
+
+func (cs ComponentService) DeleteProperty(ctx context.Context, componentUUID, propertyUUID uuid.UUID) (err error) {
+	err = cs.client.assertServerVersionAtLeast("4.11.0")
+	if err != nil {
+		return
+	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/component/%s/property/%s", componentUUID, propertyUUID))
+	if err != nil {
+		return
+	}
+
+	_, err = cs.client.doRequest(req, nil)
+	return
+}
+
+func (cs ComponentService) GetByHash(ctx context.Context, hash string, po PageOptions, so SortOptions) (p Page[Component], err error) {
+	err = cs.client.assertServerVersionAtLeast("3.0.0")
+	if err != nil {
+		return
+	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/hash/%s", hash), withPageOptions(po), withSortOptions(so))
+	if err != nil {
+		return
+	}
+
+	res, err := cs.client.doRequest(req, &p.Items)
+	if err != nil {
+		return
+	}
+
+	if cs.client.isServerVersionAtLeast("4.0.0") {
+		p.TotalCount = res.TotalCount
+	} else {
+		p.TotalCount = len(p.Items)
+	}
+	return
+}
+
+func (cs ComponentService) GetByIdentity(ctx context.Context, po PageOptions, so SortOptions, io ComponentIdentityQueryOptions) (p Page[Component], err error) {
+	err = cs.client.assertServerVersionAtLeast("4.0.0")
+	if err != nil {
+		return
+	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodGet, "/api/v1/component/identity", withPageOptions(po), withSortOptions(so), withComponentIdentityOptions(io))
+	if err != nil {
+		return
+	}
+
+	res, err := cs.client.doRequest(req, &p.Items)
+	if err != nil {
+		return
+	}
+
+	p.TotalCount = res.TotalCount
+	return
+}
+
+func withComponentIdentityOptions(identityOptions ComponentIdentityQueryOptions) requestOption {
+	return func(req *http.Request) error {
+		query := req.URL.Query()
+		if len(identityOptions.Group) > 0 {
+			query.Set("group", identityOptions.Group)
+		}
+		if len(identityOptions.Name) > 0 {
+			query.Set("name", identityOptions.Name)
+		}
+		if len(identityOptions.Version) > 0 {
+			query.Set("version", identityOptions.Version)
+		}
+		if len(identityOptions.PURL) > 0 {
+			query.Set("purl", identityOptions.PURL)
+		}
+		if len(identityOptions.CPE) > 0 {
+			query.Set("cpe", identityOptions.CPE)
+		}
+		if len(identityOptions.SWIDTagID) > 0 {
+			query.Set("swidTagId", identityOptions.SWIDTagID)
+		}
+		if identityOptions.Project != uuid.Nil {
+			query.Set("project", identityOptions.Project.String())
+		}
+		req.URL.RawQuery = query.Encode()
+		return nil
+	}
+}
+
+func (cs ComponentService) IdentifyInternal(ctx context.Context) (err error) {
+	err = cs.client.assertServerVersionAtLeast("4.0.0")
+	if err != nil {
+		return
+	}
+
+	req, err := cs.client.newRequest(ctx, http.MethodGet, "/api/v1/component/internal/identify")
+	if err != nil {
+		return
+	}
+
+	_, err = cs.client.doRequest(req, nil)
 	return
 }

--- a/component.go
+++ b/component.go
@@ -158,7 +158,7 @@ func (cs ComponentService) Update(ctx context.Context, component Component) (c C
 }
 
 func (cs ComponentService) Delete(ctx context.Context, componentUUID uuid.UUID) (err error) {
-	err = cs.client.assertServerVersionAtLeast("3.3.0")
+	err = cs.client.assertServerVersionAtLeast("3.0.0")
 	if err != nil {
 		return
 	}

--- a/component_test.go
+++ b/component_test.go
@@ -1,0 +1,216 @@
+package dtrack
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestComponentLifecycle(t *testing.T) {
+	po := PageOptions{PageSize: 10}
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+			PermissionSystemConfiguration,
+			PermissionViewPortfolio,
+		},
+	})
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "TestComponentLifecycleProject",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+	require.Equal(t, project.Name, "TestComponentLifecycleProject")
+
+	// Check absence
+	{
+		components, err := client.Component.GetAll(context.Background(), project.UUID, po, ComponentFilterOptions{})
+		require.NoError(t, err)
+		require.Equal(t, components.TotalCount, 0)
+		require.Empty(t, components.Items)
+	}
+
+	// Create Component
+	component, err := client.Component.Create(context.Background(), project.UUID, Component{
+		Name:       "Component-Name",
+		Version:    "1.2.3",
+		Classifier: "APPLICATION",
+	})
+	require.NoError(t, err)
+	require.Equal(t, component.Name, "Component-Name")
+
+	// Check presence
+	{
+		components, err := client.Component.GetAll(context.Background(), project.UUID, po, ComponentFilterOptions{})
+		require.NoError(t, err)
+		require.Equal(t, components.TotalCount, 1)
+		require.Equal(t, len(components.Items), 1)
+		require.Equal(t, components.Items[0].UUID, component.UUID)
+	}
+
+	// Update component
+	{
+		component.Name = component.Name + "-With-Change"
+		newComponent, err := client.Component.Update(context.Background(), component)
+		require.NoError(t, err)
+		require.Equal(t, newComponent.UUID, component.UUID)
+		require.Equal(t, newComponent.Name, component.Name)
+	}
+
+	// Check values
+	{
+		singleComponent, err := client.Component.Get(context.Background(), component.UUID)
+		require.NoError(t, err)
+		require.Equal(t, singleComponent.UUID, component.UUID)
+		require.Equal(t, singleComponent.Name, "Component-Name-With-Change")
+	}
+
+	// Delete
+	{
+		err := client.Component.Delete(context.Background(), component.UUID)
+		require.NoError(t, err)
+	}
+
+	// Check absence
+	{
+		components, err := client.Component.GetAll(context.Background(), project.UUID, po, ComponentFilterOptions{})
+		require.NoError(t, err)
+		require.Equal(t, components.TotalCount, 0)
+		require.Empty(t, components.Items)
+	}
+}
+
+func TestComponentPropertyLifecycle(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+			PermissionViewPortfolio,
+		},
+	})
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "TestComponentPropertyLifecycleProject",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+	require.Equal(t, project.Name, "TestComponentPropertyLifecycleProject")
+
+	component, err := client.Component.Create(context.Background(), project.UUID, Component{
+		Name:       "Component-Name",
+		Version:    "1.2.3",
+		Classifier: "APPLICATION",
+	})
+	require.NoError(t, err)
+	require.Equal(t, component.Name, "Component-Name")
+
+	// Check absence
+	{
+		components, err := client.Component.GetProperties(context.Background(), component.UUID)
+		require.NoError(t, err)
+		require.Empty(t, components)
+	}
+
+	// Create
+	property, err := client.Component.CreateProperty(context.Background(), component.UUID, ComponentProperty{
+		Group:       "Property-Group",
+		Name:        "Property-Name",
+		Value:       "Property-Value",
+		Type:        "STRING",
+		Description: "Property-Description",
+	})
+	require.NoError(t, err)
+	require.Equal(t, property.Group, "Property-Group")
+	require.Equal(t, property.Name, "Property-Name")
+	require.Equal(t, property.Value, "Property-Value")
+	require.Equal(t, property.Type, "STRING")
+	require.Equal(t, property.Description, "Property-Description")
+
+	// Check presence
+	{
+		properties, err := client.Component.GetProperties(context.Background(), component.UUID)
+		require.NoError(t, err)
+		require.Equal(t, len(properties), 1)
+		require.Equal(t, properties[0], property)
+	}
+
+	// Delete
+	{
+		err := client.Component.DeleteProperty(context.Background(), component.UUID, property.UUID)
+		require.NoError(t, err)
+	}
+
+	// Check absence
+	{
+		components, err := client.Component.GetProperties(context.Background(), component.UUID)
+		require.NoError(t, err)
+		require.Empty(t, components)
+	}
+}
+
+func TestComponentLocate(t *testing.T) {
+	po := PageOptions{PageSize: 10}
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+			PermissionViewPortfolio,
+		},
+	})
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "TestLocateComponentProject",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+	require.Equal(t, project.Name, "TestLocateComponentProject")
+
+	component, err := client.Component.Create(context.Background(), project.UUID, Component{
+		Name:       "Component-Name",
+		Version:    "1.2.3",
+		Classifier: "APPLICATION",
+		MD5:        "0123456789abcdef0123456789abcdef",
+	})
+	require.NoError(t, err)
+	require.Equal(t, component.Name, "Component-Name")
+	require.Equal(t, component.MD5, "0123456789abcdef0123456789abcdef")
+
+	// Hash
+	{
+		components, err := client.Component.GetByHash(context.Background(), "0123456789abcdef0123456789abcdef", po, SortOptions{})
+		require.NoError(t, err)
+		require.Equal(t, components.TotalCount, 1)
+
+		require.Nil(t, components.Items[0].Project.Tags)
+		require.Nil(t, components.Items[0].Project.Properties)
+		components.Items[0].Project.Tags = []Tag{}
+		components.Items[0].Project.Properties = []ProjectProperty{}
+
+		require.Equal(t, components.Items[0], component)
+	}
+
+	// Identity
+	{
+		components, err := client.Component.GetByIdentity(context.Background(), po, SortOptions{}, ComponentIdentityQueryOptions{
+			Name: "Component-Name",
+		})
+		require.NoError(t, err)
+		require.Equal(t, components.TotalCount, 1)
+
+		require.Nil(t, components.Items[0].Project.Tags)
+		require.Nil(t, components.Items[0].Project.Properties)
+		components.Items[0].Project.Tags = []Tag{}
+		components.Items[0].Project.Properties = []ProjectProperty{}
+
+		require.Equal(t, components.Items[0], component)
+	}
+}
+
+func TestComponentIdentifyInternal(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionSystemConfiguration,
+		},
+	})
+	err := client.Component.IdentifyInternal(context.Background())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
- Add bindings for `/api/v1/component` routes.
  - Except `/api/v1/component/project/{projectUuid}/dependencyGraph/{componentUuids}`, as would fit better with other `/api/v1/dependencyGraph` methods.
- Add API version checks for methods within `ComponentService`, noting change from non-paginated to paginated for `GetByHash` from `3.8.0` to `4.0.0`.
- Add `Component` and `ComponentProperty` lifecycle unit tests for `ComponentService`.

CC https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/92