### PR TITLE
Add return event token when VEX upload

### DIFF
--- a/vex.go
+++ b/vex.go
@@ -19,6 +19,12 @@ type VEXUploadRequest struct {
 	VEX            string     `json:"vex"`
 }
 
+type vexUploadResponse struct {
+	Token VEXUploadToken `json:"token"`
+}
+
+type VEXUploadToken string
+
 func (vs VEXService) ExportCycloneDX(ctx context.Context, projectUUID uuid.UUID) (vex string, err error) {
 	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/vex/cyclonedx/project/%s", projectUUID))
 	if err != nil {
@@ -31,12 +37,15 @@ func (vs VEXService) ExportCycloneDX(ctx context.Context, projectUUID uuid.UUID)
 	return
 }
 
-func (vs VEXService) Upload(ctx context.Context, uploadReq VEXUploadRequest) (err error) {
+func (vs VEXService) Upload(ctx context.Context, uploadReq VEXUploadRequest) (token VEXUploadToken, err error) {
 	req, err := vs.client.newRequest(ctx, http.MethodPut, "/api/v1/vex", withBody(uploadReq))
 	if err != nil {
 		return
 	}
 
-	_, err = vs.client.doRequest(req, nil)
+	var uploadRes vexUploadResponse
+	_, err = vs.client.doRequest(req, &uploadRes)
+
+	token = uploadRes.Token
 	return
 }


### PR DESCRIPTION
Added the ability to track the status of VEX processing:

Usage example:
```
token, err := client.VEX.Upload(context.TODO(),vexReq)
if err != nil {
       log.Fatal(err)
}
wait, err := client.Event.IsBeingProcessed(context.TODO(), dtrack.EventToken(token))
for {
        if wait {
                log.Info("VEX Processing")
                time.Sleep(time.Duration(5 * time.Second))
                wait, err = client.Event.IsBeingProcessed(context.TODO(), dtrack.EventToken(token))
        } else {
                log.Info("VEX Processing SUCCESS")
                break
        }
}
```