### PR TITLE
fix: Project Collection Tag

### DIFF
--- a/project.go
+++ b/project.go
@@ -41,7 +41,7 @@ type Project struct {
 	LastBOMImport      int                 `json:"lastBomImport"`
 	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
 	CollectionLogic    CollectionLogic     `json:"collectionLogic,omitempty"`
-	CollectionTag      string              `json:"collectionTag,omitempty"`
+	CollectionTag      Tag                 `json:"collectionTag,omitempty"`
 }
 
 type ParentRef struct {

--- a/project.go
+++ b/project.go
@@ -40,8 +40,8 @@ type Project struct {
 	ParentRef          *ParentRef          `json:"parent,omitempty"`
 	LastBOMImport      int                 `json:"lastBomImport"`
 	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
-	CollectionLogic    CollectionLogic     `json:"collectionLogic,omitempty"`
-	CollectionTag      Tag                 `json:"collectionTag,omitempty"`
+	CollectionLogic    *CollectionLogic    `json:"collectionLogic,omitempty"` // Since v4.13.0
+	CollectionTag      *Tag                `json:"collectionTag,omitempty"`   // Since v4.13.0
 }
 
 type ParentRef struct {

--- a/project_test.go
+++ b/project_test.go
@@ -43,7 +43,7 @@ func TestProjectService_CreateWithCollection(t *testing.T) {
 		Name:            "acme-app",
 		Version:         "1.0.0",
 		Active:          true,
-		CollectionLogic: CollectionLogicAggregateDirectChildren,
+		CollectionLogic: &CollectionLogicAggregateDirectChildren,
 	})
 	require.NoError(t, err)
 
@@ -55,8 +55,8 @@ func TestProjectService_CreateWithCollection(t *testing.T) {
 		Name:            "acme-app-2",
 		Version:         "1.0.0",
 		Active:          true,
-		CollectionLogic: CollectionLogicAggregateDirectChildrenWithTag,
-		CollectionTag:   Tag{Name: tag},
+		CollectionLogic: &CollectionLogicAggregateDirectChildrenWithTag,
+		CollectionTag:   &Tag{Name: tag},
 	})
 	require.NoError(t, err)
 

--- a/project_test.go
+++ b/project_test.go
@@ -56,6 +56,7 @@ func TestProjectService_CreateWithCollection(t *testing.T) {
 		Version:         "1.0.0",
 		Active:          true,
 		CollectionLogic: CollectionLogicAggregateDirectChildrenWithTag,
+		CollectionTag:   Tag{Name: tag},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
- Fix `Project.CollectionTag` from  `string` to  `Tag`, to match API response.
- Update `Project.CollectionLogic` and `Project.CollectionTag` to be pointers, to not break support for API versions prior to 4.13.
- Specify `CollectionTag` within `TestProjectService_CreateWithCollection` to verify the JSON marshalling / unmarshalling.