### PR TITLE
fix: correctly perform requests for dt deployed on subpaths

### DIFF
--- a/about.go
+++ b/about.go
@@ -28,7 +28,7 @@ type AboutService struct {
 }
 
 func (as AboutService) Get(ctx context.Context) (a About, err error) {
-	req, err := as.client.newRequest(ctx, http.MethodGet, "/api/version", withoutAuth())
+	req, err := as.client.newRequest(ctx, http.MethodGet, "api/version", withoutAuth())
 	if err != nil {
 		return
 	}

--- a/acl.go
+++ b/acl.go
@@ -18,7 +18,7 @@ type ACLMappingRequest struct {
 }
 
 func (as ACLService) AddProjectMapping(ctx context.Context, mapping ACLMappingRequest) (err error) {
-	req, err := as.client.newRequest(ctx, http.MethodPut, "/api/v1/acl/mapping", withBody(mapping))
+	req, err := as.client.newRequest(ctx, http.MethodPut, "api/v1/acl/mapping", withBody(mapping))
 	if err != nil {
 		return
 	}
@@ -27,7 +27,7 @@ func (as ACLService) AddProjectMapping(ctx context.Context, mapping ACLMappingRe
 }
 
 func (as ACLService) RemoveProjectMapping(ctx context.Context, team, project uuid.UUID) (err error) {
-	req, err := as.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/acl/mapping/team/%s/project/%s", team, project))
+	req, err := as.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/acl/mapping/team/%s/project/%s", team, project))
 	if err != nil {
 		return
 	}
@@ -36,7 +36,7 @@ func (as ACLService) RemoveProjectMapping(ctx context.Context, team, project uui
 }
 
 func (as ACLService) GetAllProjects(ctx context.Context, team uuid.UUID, po PageOptions) (p Page[Project], err error) {
-	req, err := as.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/acl/team/%s", team), withPageOptions(po))
+	req, err := as.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/acl/team/%s", team), withPageOptions(po))
 	if err != nil {
 		return
 	}

--- a/analysis.go
+++ b/analysis.go
@@ -82,7 +82,7 @@ func (as AnalysisService) Get(ctx context.Context, component, project, vulnerabi
 		"vulnerability": vulnerability.String(),
 	}
 
-	req, err := as.client.newRequest(ctx, http.MethodGet, "/api/v1/analysis", withParams(params))
+	req, err := as.client.newRequest(ctx, http.MethodGet, "api/v1/analysis", withParams(params))
 	if err != nil {
 		return
 	}
@@ -92,7 +92,7 @@ func (as AnalysisService) Get(ctx context.Context, component, project, vulnerabi
 }
 
 func (as AnalysisService) Create(ctx context.Context, analysisReq AnalysisRequest) (a Analysis, err error) {
-	req, err := as.client.newRequest(ctx, http.MethodPut, "/api/v1/analysis", withBody(analysisReq))
+	req, err := as.client.newRequest(ctx, http.MethodPut, "api/v1/analysis", withBody(analysisReq))
 	if err != nil {
 		return
 	}

--- a/bom.go
+++ b/bom.go
@@ -54,7 +54,7 @@ func (bs BOMService) ExportComponent(ctx context.Context, componentUUID uuid.UUI
 		params["format"] = string(format)
 	}
 
-	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/bom/cyclonedx/component/%s", componentUUID), withParams(params))
+	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/bom/cyclonedx/component/%s", componentUUID), withParams(params))
 	if err != nil {
 		return
 	}
@@ -74,7 +74,7 @@ func (bs BOMService) ExportProject(ctx context.Context, projectUUID uuid.UUID, f
 		params["variant"] = string(variant)
 	}
 
-	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/bom/cyclonedx/project/%s", projectUUID), withParams(params))
+	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/bom/cyclonedx/project/%s", projectUUID), withParams(params))
 	if err != nil {
 		return
 	}
@@ -86,7 +86,7 @@ func (bs BOMService) ExportProject(ctx context.Context, projectUUID uuid.UUID, f
 }
 
 func (bs BOMService) Upload(ctx context.Context, uploadReq BOMUploadRequest) (token BOMUploadToken, err error) {
-	req, err := bs.client.newRequest(ctx, http.MethodPut, "/api/v1/bom", withBody(uploadReq))
+	req, err := bs.client.newRequest(ctx, http.MethodPut, "api/v1/bom", withBody(uploadReq))
 	if err != nil {
 		return
 	}
@@ -138,7 +138,7 @@ func (bs BOMService) PostBom(ctx context.Context, uploadReq BOMUploadRequest) (t
 		params["bom"] = append(params["bom"], uploadReq.BOM)
 	}
 
-	req, err := bs.client.newRequest(ctx, http.MethodPost, "/api/v1/bom", withMultiPart(params))
+	req, err := bs.client.newRequest(ctx, http.MethodPost, "api/v1/bom", withMultiPart(params))
 	if err != nil {
 		return
 	}
@@ -165,7 +165,7 @@ func (bs BOMService) IsBeingProcessed(ctx context.Context, token BOMUploadToken)
 		return bs.client.Event.IsBeingProcessed(ctx, EventToken(token))
 	}
 
-	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/bom/token/%s", token))
+	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/bom/token/%s", token))
 	if err != nil {
 		return false, err
 	}

--- a/component.go
+++ b/component.go
@@ -84,7 +84,7 @@ func (cs ComponentService) Get(ctx context.Context, componentUUID uuid.UUID) (c 
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/%s", componentUUID))
+	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/component/%s", componentUUID))
 	if err != nil {
 		return
 	}
@@ -99,7 +99,7 @@ func (cs ComponentService) GetAll(ctx context.Context, projectUUID uuid.UUID, po
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/project/%s", projectUUID), withPageOptions(po), withComponentFilterOptions(filterOptions))
+	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/component/project/%s", projectUUID), withPageOptions(po), withComponentFilterOptions(filterOptions))
 	if err != nil {
 		return
 	}
@@ -133,7 +133,7 @@ func (cs ComponentService) Create(ctx context.Context, projectUUID uuid.UUID, co
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/component/project/%s", projectUUID), withBody(component))
+	req, err := cs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("api/v1/component/project/%s", projectUUID), withBody(component))
 	if err != nil {
 		return
 	}
@@ -148,7 +148,7 @@ func (cs ComponentService) Update(ctx context.Context, component Component) (c C
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodPost, "/api/v1/component", withBody(component))
+	req, err := cs.client.newRequest(ctx, http.MethodPost, "api/v1/component", withBody(component))
 	if err != nil {
 		return
 	}
@@ -163,7 +163,7 @@ func (cs ComponentService) Delete(ctx context.Context, componentUUID uuid.UUID) 
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/component/%s", componentUUID))
+	req, err := cs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/component/%s", componentUUID))
 	if err != nil {
 		return
 	}
@@ -178,7 +178,7 @@ func (cs ComponentService) GetProperties(ctx context.Context, componentUUID uuid
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/%s/property", componentUUID))
+	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/component/%s/property", componentUUID))
 	if err != nil {
 		return
 	}
@@ -193,7 +193,7 @@ func (cs ComponentService) CreateProperty(ctx context.Context, componentUUID uui
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/component/%s/property", componentUUID), withBody(property))
+	req, err := cs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("api/v1/component/%s/property", componentUUID), withBody(property))
 	if err != nil {
 		return
 	}
@@ -208,7 +208,7 @@ func (cs ComponentService) DeleteProperty(ctx context.Context, componentUUID, pr
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/component/%s/property/%s", componentUUID, propertyUUID))
+	req, err := cs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/component/%s/property/%s", componentUUID, propertyUUID))
 	if err != nil {
 		return
 	}
@@ -223,7 +223,7 @@ func (cs ComponentService) GetByHash(ctx context.Context, hash string, po PageOp
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/component/hash/%s", hash), withPageOptions(po), withSortOptions(so))
+	req, err := cs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/component/hash/%s", hash), withPageOptions(po), withSortOptions(so))
 	if err != nil {
 		return
 	}
@@ -247,7 +247,7 @@ func (cs ComponentService) GetByIdentity(ctx context.Context, po PageOptions, so
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodGet, "/api/v1/component/identity", withPageOptions(po), withSortOptions(so), withComponentIdentityOptions(io))
+	req, err := cs.client.newRequest(ctx, http.MethodGet, "api/v1/component/identity", withPageOptions(po), withSortOptions(so), withComponentIdentityOptions(io))
 	if err != nil {
 		return
 	}
@@ -296,7 +296,7 @@ func (cs ComponentService) IdentifyInternal(ctx context.Context) (err error) {
 		return
 	}
 
-	req, err := cs.client.newRequest(ctx, http.MethodGet, "/api/v1/component/internal/identify")
+	req, err := cs.client.newRequest(ctx, http.MethodGet, "api/v1/component/internal/identify")
 	if err != nil {
 		return
 	}

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ type ConfigService struct {
 }
 
 func (cs ConfigService) GetAll(ctx context.Context) (cps []ConfigProperty, err error) {
-	req, err := cs.client.newRequest(ctx, http.MethodGet, "/api/v1/configProperty")
+	req, err := cs.client.newRequest(ctx, http.MethodGet, "api/v1/configProperty")
 	if err != nil {
 		return
 	}
@@ -46,7 +46,7 @@ func (cs ConfigService) Get(ctx context.Context, groupName, propertyName string)
 }
 
 func (cs ConfigService) Update(ctx context.Context, config ConfigProperty) (cp ConfigProperty, err error) {
-	req, err := cs.client.newRequest(ctx, http.MethodPost, "/api/v1/configProperty", withBody(config))
+	req, err := cs.client.newRequest(ctx, http.MethodPost, "api/v1/configProperty", withBody(config))
 	if err != nil {
 		return
 	}
@@ -55,7 +55,7 @@ func (cs ConfigService) Update(ctx context.Context, config ConfigProperty) (cp C
 }
 
 func (cs ConfigService) UpdateAll(ctx context.Context, configs []ConfigProperty) (cps []ConfigProperty, err error) {
-	req, err := cs.client.newRequest(ctx, http.MethodPost, "/api/v1/configProperty/aggregate", withBody(configs))
+	req, err := cs.client.newRequest(ctx, http.MethodPost, "api/v1/configProperty/aggregate", withBody(configs))
 	if err != nil {
 		return
 	}

--- a/event.go
+++ b/event.go
@@ -27,7 +27,7 @@ func (es EventService) IsBeingProcessed(ctx context.Context, token EventToken) (
 		return false, err
 	}
 
-	req, err := es.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/event/token/%s", token))
+	req, err := es.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/event/token/%s", token))
 	if err != nil {
 		return false, err
 	}

--- a/finding.go
+++ b/finding.go
@@ -72,7 +72,7 @@ func (f FindingService) GetAll(ctx context.Context, projectUUID uuid.UUID, suppr
 		"suppressed": strconv.FormatBool(suppressed),
 	}
 
-	req, err := f.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/finding/project/%s", projectUUID), withParams(params), withPageOptions(po))
+	req, err := f.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/finding/project/%s", projectUUID), withParams(params), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -88,7 +88,7 @@ func (f FindingService) GetAll(ctx context.Context, projectUUID uuid.UUID, suppr
 
 // ExportFPF exports the findings of a given project in the File Packaging Format (FPF).
 func (f FindingService) ExportFPF(ctx context.Context, projectUUID uuid.UUID) (d []byte, err error) {
-	req, err := f.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/finding/project/%s/export", projectUUID))
+	req, err := f.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/finding/project/%s/export", projectUUID))
 	if err != nil {
 		return
 	}
@@ -106,7 +106,7 @@ func (f FindingService) ExportFPF(ctx context.Context, projectUUID uuid.UUID) (d
 // AnalyzeProject triggers an analysis for a given project.
 // This feature is available in Dependency-Track v4.7.0 and newer.
 func (f FindingService) AnalyzeProject(ctx context.Context, projectUUID uuid.UUID) (token BOMUploadToken, err error) {
-	req, err := f.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/finding/project/%s/analyze", projectUUID))
+	req, err := f.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/finding/project/%s/analyze", projectUUID))
 	if err != nil {
 		return
 	}

--- a/ldap.go
+++ b/ldap.go
@@ -31,7 +31,7 @@ type MappedLdapGroup struct {
 }
 
 func (s LDAPService) AddMapping(ctx context.Context, mapping MappedLdapGroupRequest) (g MappedLdapGroup, err error) {
-	req, err := s.client.newRequest(ctx, http.MethodPut, "/api/v1/ldap/mapping", withBody(mapping))
+	req, err := s.client.newRequest(ctx, http.MethodPut, "api/v1/ldap/mapping", withBody(mapping))
 	if err != nil {
 		return
 	}
@@ -41,7 +41,7 @@ func (s LDAPService) AddMapping(ctx context.Context, mapping MappedLdapGroupRequ
 }
 
 func (s LDAPService) RemoveMapping(ctx context.Context, mappingId uuid.UUID) (err error) {
-	req, err := s.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/ldap/mapping/%s", mappingId.String()))
+	req, err := s.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/ldap/mapping/%s", mappingId.String()))
 	if err != nil {
 		return
 	}
@@ -51,7 +51,7 @@ func (s LDAPService) RemoveMapping(ctx context.Context, mappingId uuid.UUID) (er
 }
 
 func (s LDAPService) GetAllAccessibleGroups(ctx context.Context, po PageOptions) (gs Page[string], err error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/api/v1/ldap/groups", withPageOptions(po))
+	req, err := s.client.newRequest(ctx, http.MethodGet, "api/v1/ldap/groups", withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -62,7 +62,7 @@ func (s LDAPService) GetAllAccessibleGroups(ctx context.Context, po PageOptions)
 }
 
 func (s LDAPService) GetTeamMappings(ctx context.Context, teamUUID uuid.UUID) (gs []MappedLdapGroup, err error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/ldap/team/%s", teamUUID.String()))
+	req, err := s.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/ldap/team/%s", teamUUID.String()))
 	if err != nil {
 		return
 	}
@@ -72,7 +72,7 @@ func (s LDAPService) GetTeamMappings(ctx context.Context, teamUUID uuid.UUID) (g
 }
 
 func (s LDAPService) GetUsers(ctx context.Context, po PageOptions) (us Page[LdapUser], err error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/api/v1/user/ldap", withPageOptions(po))
+	req, err := s.client.newRequest(ctx, http.MethodGet, "api/v1/user/ldap", withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -83,7 +83,7 @@ func (s LDAPService) GetUsers(ctx context.Context, po PageOptions) (us Page[Ldap
 }
 
 func (s LDAPService) CreateUser(ctx context.Context, user LdapUser) (userOut LdapUser, err error) {
-	req, err := s.client.newRequest(ctx, http.MethodPut, "/api/v1/user/ldap", withBody(user))
+	req, err := s.client.newRequest(ctx, http.MethodPut, "api/v1/user/ldap", withBody(user))
 	if err != nil {
 		return
 	}
@@ -93,7 +93,7 @@ func (s LDAPService) CreateUser(ctx context.Context, user LdapUser) (userOut Lda
 }
 
 func (s LDAPService) DeleteUser(ctx context.Context, user LdapUser) (err error) {
-	req, err := s.client.newRequest(ctx, http.MethodDelete, "/api/v1/user/ldap", withBody(user))
+	req, err := s.client.newRequest(ctx, http.MethodDelete, "api/v1/user/ldap", withBody(user))
 	if err != nil {
 		return
 	}

--- a/license.go
+++ b/license.go
@@ -26,7 +26,7 @@ type LicenseService struct {
 }
 
 func (l LicenseService) GetAll(ctx context.Context, po PageOptions) (p Page[License], err error) {
-	req, err := l.client.newRequest(ctx, http.MethodGet, "/api/v1/license", withPageOptions(po))
+	req, err := l.client.newRequest(ctx, http.MethodGet, "api/v1/license", withPageOptions(po))
 	if err != nil {
 		return
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -82,7 +82,7 @@ type MetricsService struct {
 }
 
 func (ms MetricsService) LatestPortfolioMetrics(ctx context.Context) (m PortfolioMetrics, err error) {
-	req, err := ms.client.newRequest(ctx, http.MethodGet, "/api/v1/metrics/portfolio/current")
+	req, err := ms.client.newRequest(ctx, http.MethodGet, "api/v1/metrics/portfolio/current")
 	if err != nil {
 		return
 	}
@@ -92,7 +92,7 @@ func (ms MetricsService) LatestPortfolioMetrics(ctx context.Context) (m Portfoli
 }
 
 func (ms MetricsService) PortfolioMetricsSince(ctx context.Context, date time.Time) (m []PortfolioMetrics, err error) {
-	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/metrics/portfolio/since/%s", date.Format("20060102")))
+	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/metrics/portfolio/since/%s", date.Format("20060102")))
 	if err != nil {
 		return
 	}
@@ -102,7 +102,7 @@ func (ms MetricsService) PortfolioMetricsSince(ctx context.Context, date time.Ti
 }
 
 func (ms MetricsService) PortfolioMetricsSinceDays(ctx context.Context, days uint) (m []PortfolioMetrics, err error) {
-	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/metrics/portfolio/%d/days", days))
+	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/metrics/portfolio/%d/days", days))
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (ms MetricsService) PortfolioMetricsSinceDays(ctx context.Context, days uin
 }
 
 func (ms MetricsService) RefreshPortfolioMetrics(ctx context.Context) (err error) {
-	req, err := ms.client.newRequest(ctx, http.MethodGet, "/api/v1/metrics/portfolio/refresh")
+	req, err := ms.client.newRequest(ctx, http.MethodGet, "api/v1/metrics/portfolio/refresh")
 	if err != nil {
 		return
 	}
@@ -122,7 +122,7 @@ func (ms MetricsService) RefreshPortfolioMetrics(ctx context.Context) (err error
 }
 
 func (ms MetricsService) LatestProjectMetrics(ctx context.Context, projectUUID uuid.UUID) (m ProjectMetrics, err error) {
-	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/metrics/project/%s/current", projectUUID))
+	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/metrics/project/%s/current", projectUUID))
 	if err != nil {
 		return
 	}
@@ -132,7 +132,7 @@ func (ms MetricsService) LatestProjectMetrics(ctx context.Context, projectUUID u
 }
 
 func (ms MetricsService) ProjectMetricsSince(ctx context.Context, projectUUID uuid.UUID, date time.Time) (m []ProjectMetrics, err error) {
-	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/metrics/project/%s/since/%s", projectUUID, date.Format("20060102")))
+	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/metrics/project/%s/since/%s", projectUUID, date.Format("20060102")))
 	if err != nil {
 		return
 	}
@@ -142,7 +142,7 @@ func (ms MetricsService) ProjectMetricsSince(ctx context.Context, projectUUID uu
 }
 
 func (ms MetricsService) ProjectMetricsSinceDays(ctx context.Context, projectUUID uuid.UUID, days uint) (m []ProjectMetrics, err error) {
-	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/metrics/project/%s/days/%d", projectUUID, days))
+	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/metrics/project/%s/days/%d", projectUUID, days))
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (ms MetricsService) ProjectMetricsSinceDays(ctx context.Context, projectUUI
 }
 
 func (ms MetricsService) RefreshProjectMetrics(ctx context.Context, projectUUID uuid.UUID) (err error) {
-	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/metrics/project/%s/refresh", projectUUID))
+	req, err := ms.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/metrics/project/%s/refresh", projectUUID))
 	if err != nil {
 		return
 	}

--- a/oidc.go
+++ b/oidc.go
@@ -29,7 +29,7 @@ type OIDCMapping struct {
 }
 
 func (s OIDCService) Available(ctx context.Context) (available bool, err error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/api/v1/oidc/available", withAcceptContentType("text/plain"))
+	req, err := s.client.newRequest(ctx, http.MethodGet, "api/v1/oidc/available", withAcceptContentType("text/plain"))
 	if err != nil {
 		return
 	}
@@ -45,7 +45,7 @@ func (s OIDCService) Available(ctx context.Context) (available bool, err error) 
 }
 
 func (s OIDCService) GetAllGroups(ctx context.Context, po PageOptions) (p Page[OIDCGroup], err error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/api/v1/oidc/group", withPageOptions(po))
+	req, err := s.client.newRequest(ctx, http.MethodGet, "api/v1/oidc/group", withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -60,7 +60,7 @@ func (s OIDCService) GetAllGroups(ctx context.Context, po PageOptions) (p Page[O
 }
 
 func (s OIDCService) CreateGroup(ctx context.Context, name string) (g OIDCGroup, err error) {
-	req, err := s.client.newRequest(ctx, http.MethodPut, "/api/v1/oidc/group", withBody(OIDCGroup{Name: name}))
+	req, err := s.client.newRequest(ctx, http.MethodPut, "api/v1/oidc/group", withBody(OIDCGroup{Name: name}))
 	if err != nil {
 		return
 	}
@@ -69,7 +69,7 @@ func (s OIDCService) CreateGroup(ctx context.Context, name string) (g OIDCGroup,
 	return
 }
 func (s OIDCService) UpdateGroup(ctx context.Context, group OIDCGroup) (g OIDCGroup, err error) {
-	req, err := s.client.newRequest(ctx, http.MethodPost, "/api/v1/oidc/group", withBody(group))
+	req, err := s.client.newRequest(ctx, http.MethodPost, "api/v1/oidc/group", withBody(group))
 	if err != nil {
 		return
 	}
@@ -79,7 +79,7 @@ func (s OIDCService) UpdateGroup(ctx context.Context, group OIDCGroup) (g OIDCGr
 }
 
 func (s OIDCService) DeleteGroup(ctx context.Context, groupUUID uuid.UUID) (err error) {
-	req, err := s.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/oidc/group/%s", groupUUID.String()))
+	req, err := s.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/oidc/group/%s", groupUUID.String()))
 	if err != nil {
 		return
 	}
@@ -89,7 +89,7 @@ func (s OIDCService) DeleteGroup(ctx context.Context, groupUUID uuid.UUID) (err 
 }
 
 func (s OIDCService) GetAllTeamsOf(ctx context.Context, group OIDCGroup, po PageOptions) (p Page[Team], err error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/oidc/group/%s/team", group.UUID.String()), withPageOptions(po))
+	req, err := s.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/oidc/group/%s/team", group.UUID.String()), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -104,7 +104,7 @@ func (s OIDCService) GetAllTeamsOf(ctx context.Context, group OIDCGroup, po Page
 }
 
 func (s OIDCService) AddTeamMapping(ctx context.Context, mapping OIDCMappingRequest) (m OIDCMapping, err error) {
-	req, err := s.client.newRequest(ctx, http.MethodPut, "/api/v1/oidc/mapping", withBody(mapping))
+	req, err := s.client.newRequest(ctx, http.MethodPut, "api/v1/oidc/mapping", withBody(mapping))
 	if err != nil {
 		return
 	}
@@ -114,7 +114,7 @@ func (s OIDCService) AddTeamMapping(ctx context.Context, mapping OIDCMappingRequ
 }
 
 func (s OIDCService) RemoveTeamMapping(ctx context.Context, mappingID uuid.UUID) (err error) {
-	req, err := s.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/oidc/mapping/%s", mappingID.String()))
+	req, err := s.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/oidc/mapping/%s", mappingID.String()))
 	if err != nil {
 		return
 	}

--- a/permission.go
+++ b/permission.go
@@ -35,7 +35,7 @@ type Permission struct {
 }
 
 func (ps PermissionService) GetAll(ctx context.Context, po PageOptions) (p Page[Permission], err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/permission", withPageOptions(po))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "api/v1/permission", withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -50,7 +50,7 @@ func (ps PermissionService) GetAll(ctx context.Context, po PageOptions) (p Page[
 }
 
 func (ps PermissionService) AddPermissionToTeam(ctx context.Context, permission Permission, team uuid.UUID) (t Team, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/permission/%s/team/%s", permission.Name, team.String()))
+	req, err := ps.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/permission/%s/team/%s", permission.Name, team.String()))
 	if err != nil {
 		return
 	}
@@ -59,7 +59,7 @@ func (ps PermissionService) AddPermissionToTeam(ctx context.Context, permission 
 	return
 }
 func (ps PermissionService) RemovePermissionFromTeam(ctx context.Context, permission Permission, team uuid.UUID) (t Team, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/permission/%s/team/%s", permission.Name, team.String()))
+	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/permission/%s/team/%s", permission.Name, team.String()))
 	if err != nil {
 		return
 	}

--- a/policy.go
+++ b/policy.go
@@ -40,7 +40,7 @@ const (
 )
 
 func (ps PolicyService) Get(ctx context.Context, policyUUID uuid.UUID) (p Policy, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/policy/%s", policyUUID))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/policy/%s", policyUUID))
 	if err != nil {
 		return
 	}
@@ -50,7 +50,7 @@ func (ps PolicyService) Get(ctx context.Context, policyUUID uuid.UUID) (p Policy
 }
 
 func (ps PolicyService) GetAll(ctx context.Context, po PageOptions) (p Page[Policy], err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/policy", withPageOptions(po))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "api/v1/policy", withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -65,7 +65,7 @@ func (ps PolicyService) GetAll(ctx context.Context, po PageOptions) (p Page[Poli
 }
 
 func (ps PolicyService) Create(ctx context.Context, policy Policy) (p Policy, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPut, "/api/v1/policy", withBody(policy))
+	req, err := ps.client.newRequest(ctx, http.MethodPut, "api/v1/policy", withBody(policy))
 	if err != nil {
 		return
 	}
@@ -75,7 +75,7 @@ func (ps PolicyService) Create(ctx context.Context, policy Policy) (p Policy, er
 }
 
 func (ps PolicyService) Delete(ctx context.Context, policyUUID uuid.UUID) (err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/policy/%s", policyUUID))
+	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/policy/%s", policyUUID))
 	if err != nil {
 		return
 	}
@@ -85,7 +85,7 @@ func (ps PolicyService) Delete(ctx context.Context, policyUUID uuid.UUID) (err e
 }
 
 func (ps PolicyService) Update(ctx context.Context, policy Policy) (p Policy, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPost, "/api/v1/policy", withBody(policy))
+	req, err := ps.client.newRequest(ctx, http.MethodPost, "api/v1/policy", withBody(policy))
 	if err != nil {
 		return
 	}
@@ -95,7 +95,7 @@ func (ps PolicyService) Update(ctx context.Context, policy Policy) (p Policy, er
 }
 
 func (ps PolicyService) AddProject(ctx context.Context, policyUUID, projectUUID uuid.UUID) (p Policy, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/policy/%s/project/%s", policyUUID, projectUUID))
+	req, err := ps.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/policy/%s/project/%s", policyUUID, projectUUID))
 	if err != nil {
 		return
 	}
@@ -105,7 +105,7 @@ func (ps PolicyService) AddProject(ctx context.Context, policyUUID, projectUUID 
 }
 
 func (ps PolicyService) DeleteProject(ctx context.Context, policyUUID, projectUUID uuid.UUID) (p Policy, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/policy/%s/project/%s", policyUUID, projectUUID))
+	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/policy/%s/project/%s", policyUUID, projectUUID))
 	if err != nil {
 		return
 	}
@@ -115,7 +115,7 @@ func (ps PolicyService) DeleteProject(ctx context.Context, policyUUID, projectUU
 }
 
 func (ps PolicyService) AddTag(ctx context.Context, policyUUID uuid.UUID, tagName string) (p Policy, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/policy/%s/tag/%s", policyUUID, tagName))
+	req, err := ps.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/policy/%s/tag/%s", policyUUID, tagName))
 	if err != nil {
 		return
 	}
@@ -125,7 +125,7 @@ func (ps PolicyService) AddTag(ctx context.Context, policyUUID uuid.UUID, tagNam
 }
 
 func (ps PolicyService) DeleteTag(ctx context.Context, policyUUID uuid.UUID, tagName string) (p Policy, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/policy/%s/tag/%s", policyUUID, tagName))
+	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/policy/%s/tag/%s", policyUUID, tagName))
 	if err != nil {
 		return
 	}

--- a/policy_condition.go
+++ b/policy_condition.go
@@ -55,7 +55,7 @@ const (
 )
 
 func (pcs PolicyConditionService) Create(ctx context.Context, policyUUID uuid.UUID, policyCondition PolicyCondition) (p PolicyCondition, err error) {
-	req, err := pcs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/policy/%s/condition", policyUUID), withBody(policyCondition))
+	req, err := pcs.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("api/v1/policy/%s/condition", policyUUID), withBody(policyCondition))
 	if err != nil {
 		return
 	}
@@ -65,7 +65,7 @@ func (pcs PolicyConditionService) Create(ctx context.Context, policyUUID uuid.UU
 }
 
 func (pcs PolicyConditionService) Update(ctx context.Context, policyCondition PolicyCondition) (p PolicyCondition, err error) {
-	req, err := pcs.client.newRequest(ctx, http.MethodPost, "/api/v1/policy/condition", withBody(policyCondition))
+	req, err := pcs.client.newRequest(ctx, http.MethodPost, "api/v1/policy/condition", withBody(policyCondition))
 	if err != nil {
 		return
 	}
@@ -75,7 +75,7 @@ func (pcs PolicyConditionService) Update(ctx context.Context, policyCondition Po
 }
 
 func (pcs PolicyConditionService) Delete(ctx context.Context, policyConditionUUID uuid.UUID) (err error) {
-	req, err := pcs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/policy/condition/%s", policyConditionUUID))
+	req, err := pcs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/policy/condition/%s", policyConditionUUID))
 	if err != nil {
 		return
 	}

--- a/policy_violation.go
+++ b/policy_violation.go
@@ -28,7 +28,7 @@ func (pvs PolicyViolationService) GetAll(ctx context.Context, suppressed bool, p
 		"suppressed": strconv.FormatBool(suppressed),
 	}
 
-	req, err := pvs.client.newRequest(ctx, http.MethodGet, "/api/v1/violation", withParams(params), withPageOptions(po))
+	req, err := pvs.client.newRequest(ctx, http.MethodGet, "api/v1/violation", withParams(params), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -47,7 +47,7 @@ func (pvs PolicyViolationService) GetAllForProject(ctx context.Context, projectU
 		"suppressed": strconv.FormatBool(suppressed),
 	}
 
-	req, err := pvs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/violation/project/%s", projectUUID), withParams(params), withPageOptions(po))
+	req, err := pvs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/violation/project/%s", projectUUID), withParams(params), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -66,7 +66,7 @@ func (pvs PolicyViolationService) GetAllForComponent(ctx context.Context, compon
 		"suppressed": strconv.FormatBool(suppressed),
 	}
 
-	req, err := pvs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/violation/component/%s", componentUUID), withParams(params), withPageOptions(po))
+	req, err := pvs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/violation/component/%s", componentUUID), withParams(params), withPageOptions(po))
 	if err != nil {
 		return
 	}

--- a/policy_violation_analysis.go
+++ b/policy_violation_analysis.go
@@ -45,7 +45,7 @@ func (vas ViolationAnalysisService) Get(ctx context.Context, componentUUID, poli
 		"policyViolation": policyViolationUUID.String(),
 	}
 
-	req, err := vas.client.newRequest(ctx, http.MethodGet, "/api/v1/violation/analysis", withParams(params))
+	req, err := vas.client.newRequest(ctx, http.MethodGet, "api/v1/violation/analysis", withParams(params))
 	if err != nil {
 		return
 	}
@@ -55,7 +55,7 @@ func (vas ViolationAnalysisService) Get(ctx context.Context, componentUUID, poli
 }
 
 func (vas ViolationAnalysisService) Update(ctx context.Context, analysisReq ViolationAnalysisRequest) (va ViolationAnalysis, err error) {
-	req, err := vas.client.newRequest(ctx, http.MethodPut, "/api/v1/violation/analysis", withBody(analysisReq))
+	req, err := vas.client.newRequest(ctx, http.MethodPut, "api/v1/violation/analysis", withBody(analysisReq))
 	if err != nil {
 		return
 	}

--- a/project.go
+++ b/project.go
@@ -53,7 +53,7 @@ type ProjectService struct {
 }
 
 func (ps ProjectService) Get(ctx context.Context, projectUUID uuid.UUID) (p Project, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/project/%s", projectUUID))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/project/%s", projectUUID))
 	if err != nil {
 		return
 	}
@@ -63,7 +63,7 @@ func (ps ProjectService) Get(ctx context.Context, projectUUID uuid.UUID) (p Proj
 }
 
 func (ps ProjectService) GetAll(ctx context.Context, po PageOptions) (p Page[Project], err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project", withPageOptions(po))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "api/v1/project", withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -78,7 +78,7 @@ func (ps ProjectService) GetAll(ctx context.Context, po PageOptions) (p Page[Pro
 }
 
 func (ps ProjectService) Latest(ctx context.Context, name string) (p Project, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/project/latest/%s", url.PathEscape(name)))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/project/latest/%s", url.PathEscape(name)))
 	if err != nil {
 		return
 	}
@@ -93,7 +93,7 @@ func (ps ProjectService) GetProjectsForName(ctx context.Context, name string, ex
 		"onlyRoot":        strconv.FormatBool(onlyRoot),
 	}
 
-	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project", withParams(params))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "api/v1/project", withParams(params))
 	if err != nil {
 		return
 	}
@@ -103,7 +103,7 @@ func (ps ProjectService) GetProjectsForName(ctx context.Context, name string, ex
 }
 
 func (ps ProjectService) Create(ctx context.Context, project Project) (p Project, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPut, "/api/v1/project", withBody(project))
+	req, err := ps.client.newRequest(ctx, http.MethodPut, "api/v1/project", withBody(project))
 	if err != nil {
 		return
 	}
@@ -113,7 +113,7 @@ func (ps ProjectService) Create(ctx context.Context, project Project) (p Project
 }
 
 func (ps ProjectService) Patch(ctx context.Context, projectUUID uuid.UUID, project Project) (p Project, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/project/%s", projectUUID), withBody(project))
+	req, err := ps.client.newRequest(ctx, http.MethodPatch, fmt.Sprintf("api/v1/project/%s", projectUUID), withBody(project))
 	if err != nil {
 		return
 	}
@@ -123,7 +123,7 @@ func (ps ProjectService) Patch(ctx context.Context, projectUUID uuid.UUID, proje
 }
 
 func (ps ProjectService) Update(ctx context.Context, project Project) (p Project, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPost, "/api/v1/project", withBody(project))
+	req, err := ps.client.newRequest(ctx, http.MethodPost, "api/v1/project", withBody(project))
 	if err != nil {
 		return
 	}
@@ -133,7 +133,7 @@ func (ps ProjectService) Update(ctx context.Context, project Project) (p Project
 }
 
 func (ps ProjectService) Delete(ctx context.Context, projectUUID uuid.UUID) (err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/project/%s", projectUUID))
+	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/project/%s", projectUUID))
 	if err != nil {
 		return
 	}
@@ -148,7 +148,7 @@ func (ps ProjectService) Lookup(ctx context.Context, name, version string) (p Pr
 		"version": version,
 	}
 
-	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project/lookup", withParams(params))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "api/v1/project/lookup", withParams(params))
 	if err != nil {
 		return
 	}
@@ -166,7 +166,7 @@ func (ps ProjectService) GetAllByTag(ctx context.Context, tag string, excludeIna
 		"onlyRoot":        strconv.FormatBool(onlyRoot),
 	}
 
-	req, err := ps.client.newRequest(ctx, http.MethodGet, "/api/v1/project/tag/{tag}", withPathParams(pathParams), withParams(params), withPageOptions(po))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, "api/v1/project/tag/{tag}", withPathParams(pathParams), withParams(params), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -196,7 +196,7 @@ type ProjectCloneRequest struct {
 // Clone triggers a cloning operation.
 // An EventToken is only returned for server versions 4.11.0 and newer.
 func (ps ProjectService) Clone(ctx context.Context, cloneReq ProjectCloneRequest) (token EventToken, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPut, "/api/v1/project/clone", withBody(cloneReq))
+	req, err := ps.client.newRequest(ctx, http.MethodPut, "api/v1/project/clone", withBody(cloneReq))
 	if err != nil {
 		return
 	}

--- a/project_property.go
+++ b/project_property.go
@@ -21,7 +21,7 @@ type ProjectPropertyService struct {
 }
 
 func (ps ProjectPropertyService) GetAll(ctx context.Context, projectUUID uuid.UUID, po PageOptions) (p Page[ProjectProperty], err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/project/%s/property", projectUUID), withPageOptions(po))
+	req, err := ps.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/project/%s/property", projectUUID), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -36,7 +36,7 @@ func (ps ProjectPropertyService) GetAll(ctx context.Context, projectUUID uuid.UU
 }
 
 func (ps ProjectPropertyService) Create(ctx context.Context, projectUUID uuid.UUID, property ProjectProperty) (p ProjectProperty, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/project/%s/property", projectUUID), withBody(property))
+	req, err := ps.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("api/v1/project/%s/property", projectUUID), withBody(property))
 	if err != nil {
 		return
 	}
@@ -46,7 +46,7 @@ func (ps ProjectPropertyService) Create(ctx context.Context, projectUUID uuid.UU
 }
 
 func (ps ProjectPropertyService) Update(ctx context.Context, projectUUID uuid.UUID, property ProjectProperty) (p ProjectProperty, err error) {
-	req, err := ps.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/project/%s/property", projectUUID), withBody(property))
+	req, err := ps.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/project/%s/property", projectUUID), withBody(property))
 	if err != nil {
 		return
 	}
@@ -61,7 +61,7 @@ func (ps ProjectPropertyService) Delete(ctx context.Context, projectUUID uuid.UU
 		Name:  propertyName,
 	}
 
-	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/project/%s/property", projectUUID), withBody(property))
+	req, err := ps.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/project/%s/property", projectUUID), withBody(property))
 	if err != nil {
 		return
 	}

--- a/repository.go
+++ b/repository.go
@@ -56,7 +56,7 @@ func (rs RepositoryService) GetMetaComponent(ctx context.Context, purl string) (
 		"purl": purl,
 	}
 
-	req, err := rs.client.newRequest(ctx, http.MethodGet, "/api/v1/repository/latest", withParams(params))
+	req, err := rs.client.newRequest(ctx, http.MethodGet, "api/v1/repository/latest", withParams(params))
 	if err != nil {
 		return
 	}
@@ -66,7 +66,7 @@ func (rs RepositoryService) GetMetaComponent(ctx context.Context, purl string) (
 }
 
 func (rs RepositoryService) GetAll(ctx context.Context, po PageOptions) (p Page[Repository], err error) {
-	req, err := rs.client.newRequest(ctx, http.MethodGet, "/api/v1/repository", withPageOptions(po))
+	req, err := rs.client.newRequest(ctx, http.MethodGet, "api/v1/repository", withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -81,7 +81,7 @@ func (rs RepositoryService) GetAll(ctx context.Context, po PageOptions) (p Page[
 }
 
 func (rs RepositoryService) GetByType(ctx context.Context, repoType RepositoryType, po PageOptions) (p Page[Repository], err error) {
-	req, err := rs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/repository/%s", repoType), withPageOptions(po))
+	req, err := rs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/repository/%s", repoType), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -96,7 +96,7 @@ func (rs RepositoryService) GetByType(ctx context.Context, repoType RepositoryTy
 }
 
 func (rs RepositoryService) Create(ctx context.Context, repo Repository) (r Repository, err error) {
-	req, err := rs.client.newRequest(ctx, http.MethodPut, "/api/v1/repository", withBody(repo))
+	req, err := rs.client.newRequest(ctx, http.MethodPut, "api/v1/repository", withBody(repo))
 	if err != nil {
 		return
 	}
@@ -105,7 +105,7 @@ func (rs RepositoryService) Create(ctx context.Context, repo Repository) (r Repo
 	return
 }
 func (rs RepositoryService) Update(ctx context.Context, repo Repository) (r Repository, err error) {
-	req, err := rs.client.newRequest(ctx, http.MethodPost, "/api/v1/repository", withBody(repo))
+	req, err := rs.client.newRequest(ctx, http.MethodPost, "api/v1/repository", withBody(repo))
 	if err != nil {
 		return
 	}
@@ -115,7 +115,7 @@ func (rs RepositoryService) Update(ctx context.Context, repo Repository) (r Repo
 }
 
 func (rs RepositoryService) Delete(ctx context.Context, reposUUID uuid.UUID) (err error) {
-	req, err := rs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/repository/%s", reposUUID.String()))
+	req, err := rs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/repository/%s", reposUUID.String()))
 	if err != nil {
 		return
 	}

--- a/tag.go
+++ b/tag.go
@@ -40,7 +40,7 @@ func (ts TagService) Create(ctx context.Context, names []string) (err error) {
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodPut, "/api/v1/tag", withBody(names))
+	req, err := ts.client.newRequest(ctx, http.MethodPut, "api/v1/tag", withBody(names))
 	if err != nil {
 		return
 	}
@@ -55,7 +55,7 @@ func (ts TagService) GetAll(ctx context.Context, po PageOptions, so SortOptions)
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodGet, "/api/v1/tag", withPageOptions(po), withSortOptions(so))
+	req, err := ts.client.newRequest(ctx, http.MethodGet, "api/v1/tag", withPageOptions(po), withSortOptions(so))
 	if err != nil {
 		return
 	}
@@ -75,7 +75,7 @@ func (ts TagService) Delete(ctx context.Context, names []string) (err error) {
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodDelete, "/api/v1/tag", withBody(names))
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, "api/v1/tag", withBody(names))
 	if err != nil {
 		return
 	}
@@ -90,7 +90,7 @@ func (ts TagService) TagProjects(ctx context.Context, tag string, projects []uui
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/tag/%s/project", tag), withBody(projects))
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/tag/%s/project", tag), withBody(projects))
 	if err != nil {
 		return
 	}
@@ -104,7 +104,7 @@ func (ts TagService) UntagProjects(ctx context.Context, tag string, projects []u
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/tag/%s/project", tag), withBody(projects))
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/tag/%s/project", tag), withBody(projects))
 	if err != nil {
 		return
 	}
@@ -118,7 +118,7 @@ func (ts TagService) GetProjects(ctx context.Context, tag string, po PageOptions
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/tag/%s/project", tag), withPageOptions(po), withSortOptions(so))
+	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/tag/%s/project", tag), withPageOptions(po), withSortOptions(so))
 	if err != nil {
 		return
 	}
@@ -138,7 +138,7 @@ func (ts TagService) TagPolicies(ctx context.Context, tag string, policies []uui
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/tag/%s/policy", tag), withBody(policies))
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/tag/%s/policy", tag), withBody(policies))
 	if err != nil {
 		return
 	}
@@ -152,7 +152,7 @@ func (ts TagService) UntagPolicies(ctx context.Context, tag string, policies []u
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/tag/%s/policy", tag), withBody(policies))
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/tag/%s/policy", tag), withBody(policies))
 	if err != nil {
 		return
 	}
@@ -166,7 +166,7 @@ func (ts TagService) GetPolicies(ctx context.Context, tag string, po PageOptions
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/tag/%s/policy", tag), withPageOptions(po), withSortOptions(so))
+	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/tag/%s/policy", tag), withPageOptions(po), withSortOptions(so))
 	if err != nil {
 		return
 	}
@@ -186,7 +186,7 @@ func (ts TagService) TagNotificationRules(ctx context.Context, tag string, rules
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/tag/%s/notificationRule", tag), withBody(rules))
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/tag/%s/notificationRule", tag), withBody(rules))
 	if err != nil {
 		return
 	}
@@ -200,7 +200,7 @@ func (ts TagService) UntagNotificationRules(ctx context.Context, tag string, rul
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/tag/%s/notificationRule", tag), withBody(rules))
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/tag/%s/notificationRule", tag), withBody(rules))
 	if err != nil {
 		return
 	}
@@ -214,7 +214,7 @@ func (ts TagService) GetNotificationRules(ctx context.Context, tag string, po Pa
 		return
 	}
 
-	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/tag/%s/notificationRule", tag), withPageOptions(po), withSortOptions(so))
+	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/tag/%s/notificationRule", tag), withPageOptions(po), withSortOptions(so))
 	if err != nil {
 		return
 	}
@@ -231,14 +231,14 @@ func (ts TagService) GetNotificationRules(ctx context.Context, tag string, po Pa
 func (ts TagService) GetTagsForPolicy(ctx context.Context, policy uuid.UUID, po PageOptions, so SortOptions) (p Page[Tag], err error) {
 	var req *http.Request
 	if ts.client.isServerVersionAtLeast("4.12.0") {
-		req, err = ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/tag/policy/%s", policy), withPageOptions(po), withSortOptions(so))
+		req, err = ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/tag/policy/%s", policy), withPageOptions(po), withSortOptions(so))
 	} else {
 		err = ts.client.assertServerVersionAtLeast("4.6.0")
 		if err != nil {
 			return
 		}
 
-		req, err = ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/tag/%s", policy), withPageOptions(po), withSortOptions(so))
+		req, err = ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/tag/%s", policy), withPageOptions(po), withSortOptions(so))
 	}
 	if err != nil {
 		return

--- a/team.go
+++ b/team.go
@@ -31,7 +31,7 @@ type TeamService struct {
 }
 
 func (ts TeamService) Get(ctx context.Context, teamUUID uuid.UUID) (t Team, err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/team/%s", teamUUID))
+	req, err := ts.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/team/%s", teamUUID))
 	if err != nil {
 		return
 	}
@@ -41,7 +41,7 @@ func (ts TeamService) Get(ctx context.Context, teamUUID uuid.UUID) (t Team, err 
 }
 
 func (ts TeamService) GetAll(ctx context.Context, po PageOptions) (p Page[Team], err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodGet, "/api/v1/team", withPageOptions(po))
+	req, err := ts.client.newRequest(ctx, http.MethodGet, "api/v1/team", withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -56,7 +56,7 @@ func (ts TeamService) GetAll(ctx context.Context, po PageOptions) (p Page[Team],
 }
 
 func (ts TeamService) GenerateAPIKey(ctx context.Context, teamUUID uuid.UUID) (apiKey APIKey, err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/api/v1/team/%s/key", teamUUID))
+	req, err := ts.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("api/v1/team/%s/key", teamUUID))
 	if err != nil {
 		return
 	}
@@ -66,7 +66,7 @@ func (ts TeamService) GenerateAPIKey(ctx context.Context, teamUUID uuid.UUID) (a
 }
 
 func (ts TeamService) DeleteAPIKey(ctx context.Context, publicIdOrKey string) (err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/team/key/%s", publicIdOrKey))
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/team/key/%s", publicIdOrKey))
 	if err != nil {
 		return
 	}
@@ -75,7 +75,7 @@ func (ts TeamService) DeleteAPIKey(ctx context.Context, publicIdOrKey string) (e
 }
 
 func (ts TeamService) UpdateAPIKeyComment(ctx context.Context, publicIdOrKey, comment string) (commentOut string, err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/team/key/%s/comment", publicIdOrKey), withBody(comment))
+	req, err := ts.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/team/key/%s/comment", publicIdOrKey), withBody(comment))
 	if err != nil {
 		return
 	}
@@ -101,7 +101,7 @@ func (ts TeamService) GetAPIKeys(ctx context.Context, teamUUID uuid.UUID) (keys 
 }
 
 func (ts TeamService) Create(ctx context.Context, team Team) (t Team, err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodPut, "/api/v1/team", withBody(team))
+	req, err := ts.client.newRequest(ctx, http.MethodPut, "api/v1/team", withBody(team))
 	if err != nil {
 		return
 	}
@@ -111,7 +111,7 @@ func (ts TeamService) Create(ctx context.Context, team Team) (t Team, err error)
 }
 
 func (ts TeamService) Update(ctx context.Context, team Team) (t Team, err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodPost, "/api/v1/team", withBody(team))
+	req, err := ts.client.newRequest(ctx, http.MethodPost, "api/v1/team", withBody(team))
 	if err != nil {
 		return
 	}
@@ -121,7 +121,7 @@ func (ts TeamService) Update(ctx context.Context, team Team) (t Team, err error)
 }
 
 func (ts TeamService) Delete(ctx context.Context, team Team) (err error) {
-	req, err := ts.client.newRequest(ctx, http.MethodDelete, "/api/v1/team", withBody(team))
+	req, err := ts.client.newRequest(ctx, http.MethodDelete, "api/v1/team", withBody(team))
 	if err != nil {
 		return
 	}

--- a/user.go
+++ b/user.go
@@ -15,7 +15,7 @@ func (us UserService) Login(ctx context.Context, username, password string) (tok
 	body.Set("username", username)
 	body.Set("password", password)
 
-	req, err := us.client.newRequest(ctx, http.MethodPost, "/api/v1/user/login", withBody(body))
+	req, err := us.client.newRequest(ctx, http.MethodPost, "api/v1/user/login", withBody(body))
 	if err != nil {
 		return
 	}
@@ -33,7 +33,7 @@ func (us UserService) ForceChangePassword(ctx context.Context, username, passwor
 	body.Set("newPassword", newPassword)
 	body.Set("confirmPassword", newPassword)
 
-	req, err := us.client.newRequest(ctx, http.MethodPost, "/api/v1/user/forceChangePassword", withBody(body))
+	req, err := us.client.newRequest(ctx, http.MethodPost, "api/v1/user/forceChangePassword", withBody(body))
 	if err != nil {
 		return
 	}

--- a/vex.go
+++ b/vex.go
@@ -26,7 +26,7 @@ type vexUploadResponse struct {
 type VEXUploadToken string
 
 func (vs VEXService) ExportCycloneDX(ctx context.Context, projectUUID uuid.UUID) (vex string, err error) {
-	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/vex/cyclonedx/project/%s", projectUUID))
+	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/vex/cyclonedx/project/%s", projectUUID))
 	if err != nil {
 		return
 	}
@@ -38,7 +38,7 @@ func (vs VEXService) ExportCycloneDX(ctx context.Context, projectUUID uuid.UUID)
 }
 
 func (vs VEXService) Upload(ctx context.Context, uploadReq VEXUploadRequest) (token VEXUploadToken, err error) {
-	req, err := vs.client.newRequest(ctx, http.MethodPut, "/api/v1/vex", withBody(uploadReq))
+	req, err := vs.client.newRequest(ctx, http.MethodPut, "api/v1/vex", withBody(uploadReq))
 	if err != nil {
 		return
 	}

--- a/vulnerability.go
+++ b/vulnerability.go
@@ -66,7 +66,7 @@ type VulnerabilityService struct {
 }
 
 func (vs VulnerabilityService) Get(ctx context.Context, vulnUUID uuid.UUID) (v Vulnerability, err error) {
-	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/vulnerability/%s", vulnUUID))
+	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/vulnerability/%s", vulnUUID))
 	if err != nil {
 		return
 	}
@@ -80,7 +80,7 @@ func (vs VulnerabilityService) GetAllForComponent(ctx context.Context, component
 		"suppressed": strconv.FormatBool(suppressed),
 	}
 
-	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/vulnerability/component/%s", componentUUID), withParams(params), withPageOptions(po))
+	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/vulnerability/component/%s", componentUUID), withParams(params), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -99,7 +99,7 @@ func (vs VulnerabilityService) GetAllForProject(ctx context.Context, projectUUID
 		"suppressed": strconv.FormatBool(suppressed),
 	}
 
-	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/vulnerability/project/%s", projectUUID), withParams(params), withPageOptions(po))
+	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/vulnerability/project/%s", projectUUID), withParams(params), withPageOptions(po))
 	if err != nil {
 		return
 	}
@@ -114,7 +114,7 @@ func (vs VulnerabilityService) GetAllForProject(ctx context.Context, projectUUID
 }
 
 func (vs VulnerabilityService) Assign(ctx context.Context, vulnUUID, componentUUID uuid.UUID) (err error) {
-	req, err := vs.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/vulnerability/%s/component/%s", vulnUUID, componentUUID))
+	req, err := vs.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("api/v1/vulnerability/%s/component/%s", vulnUUID, componentUUID))
 	if err != nil {
 		return
 	}
@@ -124,7 +124,7 @@ func (vs VulnerabilityService) Assign(ctx context.Context, vulnUUID, componentUU
 }
 
 func (vs VulnerabilityService) Unassign(ctx context.Context, vulnUUID, componentUUID uuid.UUID) (err error) {
-	req, err := vs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/vulnerability/%s/component/%s", vulnUUID, componentUUID))
+	req, err := vs.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("api/v1/vulnerability/%s/component/%s", vulnUUID, componentUUID))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Previously if the dependency-track baseURL was under a subpath, client-go would ignore that subpath and therefore perform requests to nonexisting urls.

The reason for the defect is the behavior of URL.Parse, which uses URL.ResolveReference. From the [docs](https://pkg.go.dev/net/url#URL.ResolveReference):
> If ref is an absolute URL, then ResolveReference ignores base and returns a copy of ref.

Therefore if the leading slash is omitted both instances on the root of a domain aswell as Dependency Track deployed on a subpath will be supported.