### PR TITLE
Fix: deletion of ProjectProperties

### DIFF
--- a/project_property.go
+++ b/project_property.go
@@ -16,6 +16,11 @@ type ProjectProperty struct {
 	Description string `json:"description"`
 }
 
+type ProjectPropertyDelete struct {
+	Group string `json:"groupName"`
+	Name  string `json:"propertyName"`
+}
+
 type ProjectPropertyService struct {
 	client *Client
 }
@@ -56,7 +61,7 @@ func (ps ProjectPropertyService) Update(ctx context.Context, projectUUID uuid.UU
 }
 
 func (ps ProjectPropertyService) Delete(ctx context.Context, projectUUID uuid.UUID, groupName, propertyName string) (err error) {
-	property := ProjectProperty{
+	property := ProjectPropertyDelete{
 		Group: groupName,
 		Name:  propertyName,
 	}

--- a/project_property.go
+++ b/project_property.go
@@ -16,11 +16,6 @@ type ProjectProperty struct {
 	Description string `json:"description"`
 }
 
-type ProjectPropertyDelete struct {
-	Group string `json:"groupName"`
-	Name  string `json:"propertyName"`
-}
-
 type ProjectPropertyService struct {
 	client *Client
 }
@@ -61,7 +56,10 @@ func (ps ProjectPropertyService) Update(ctx context.Context, projectUUID uuid.UU
 }
 
 func (ps ProjectPropertyService) Delete(ctx context.Context, projectUUID uuid.UUID, groupName, propertyName string) (err error) {
-	property := ProjectPropertyDelete{
+	property := struct {
+		Group string `json:"groupName"`
+		Name  string `json:"propertyName"`
+	}{
 		Group: groupName,
 		Name:  propertyName,
 	}

--- a/project_property_test.go
+++ b/project_property_test.go
@@ -1,0 +1,155 @@
+package dtrack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectPropertyService_GetAll(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+		},
+	})
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "acme-app",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+
+	po := PageOptions{PageSize: 10}
+
+	// Baseline: no properties yet
+	properties, err := client.ProjectProperty.GetAll(context.Background(), project.UUID, po)
+	require.NoError(t, err)
+	// The api does not return TotalCount as it seems not to be paginated (although we can supply page options)
+	//require.Equal(t, 0, properties.TotalCount)
+	require.Empty(t, properties.Items)
+
+	// Create a property
+	_, err = client.ProjectProperty.Create(context.Background(), project.UUID, ProjectProperty{
+		Group: "test-group",
+		Name:  "test-property",
+		Value: "test-value",
+		Type:  "STRING",
+	})
+	require.NoError(t, err)
+
+	// Verify it appears in GetAll
+	properties, err = client.ProjectProperty.GetAll(context.Background(), project.UUID, po)
+	require.NoError(t, err)
+	// The api does not return TotalCount as it seems not to be paginated (although we can supply page options)
+	//require.Equal(t, 1, properties.TotalCount)
+	require.Len(t, properties.Items, 1)
+	require.Equal(t, "test-group", properties.Items[0].Group)
+	require.Equal(t, "test-property", properties.Items[0].Name)
+	require.Equal(t, "test-value", properties.Items[0].Value)
+	require.Equal(t, "STRING", properties.Items[0].Type)
+}
+
+func TestProjectPropertyService_Create(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+		},
+	})
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "acme-app",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+
+	property, err := client.ProjectProperty.Create(context.Background(), project.UUID, ProjectProperty{
+		Group:       "test-group",
+		Name:        "test-property",
+		Value:       "test-value",
+		Type:        "STRING",
+		Description: "a test property",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "test-group", property.Group)
+	require.Equal(t, "test-property", property.Name)
+	require.Equal(t, "test-value", property.Value)
+	require.Equal(t, "STRING", property.Type)
+	require.Equal(t, "a test property", property.Description)
+}
+
+func TestProjectPropertyService_Update(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+		},
+	})
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "acme-app",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+
+	// Create a property first
+	_, err = client.ProjectProperty.Create(context.Background(), project.UUID, ProjectProperty{
+		Group: "test-group",
+		Name:  "test-property",
+		Value: "original-value",
+		Type:  "STRING",
+	})
+	require.NoError(t, err)
+
+	// Update the property
+	updated, err := client.ProjectProperty.Update(context.Background(), project.UUID, ProjectProperty{
+		Group: "test-group",
+		Name:  "test-property",
+		Value: "updated-value",
+		Type:  "STRING",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "test-group", updated.Group)
+	require.Equal(t, "test-property", updated.Name)
+	require.Equal(t, "updated-value", updated.Value)
+	require.Equal(t, "STRING", updated.Type)
+}
+
+func TestProjectPropertyService_Delete(t *testing.T) {
+	client := setUpContainer(t, testContainerOptions{
+		APIPermissions: []string{
+			PermissionPortfolioManagement,
+		},
+	})
+
+	po := PageOptions{PageSize: 10}
+
+	project, err := client.Project.Create(context.Background(), Project{
+		Name:    "acme-app",
+		Version: "1.0.0",
+	})
+	require.NoError(t, err)
+
+	// Create a property
+	_, err = client.ProjectProperty.Create(context.Background(), project.UUID, ProjectProperty{
+		Group: "test-group",
+		Name:  "test-property",
+		Value: "test-value",
+		Type:  "STRING",
+	})
+	require.NoError(t, err)
+
+	// Verify presence
+	properties, err := client.ProjectProperty.GetAll(context.Background(), project.UUID, po)
+	require.NoError(t, err)
+	require.Len(t, properties.Items, 1)
+
+	// Delete the property
+	err = client.ProjectProperty.Delete(context.Background(), project.UUID, "test-group", "test-property")
+	require.NoError(t, err)
+
+	// Verify absence
+	properties, err = client.ProjectProperty.GetAll(context.Background(), project.UUID, po)
+	require.NoError(t, err)
+	require.Len(t, properties.Items, 0)
+
+}


### PR DESCRIPTION
Deletion of project properties currently fails with the following error message:
```
{
  "status": 400,
  "title": "The provided JSON payload could not be mapped",
  "detail": "Cannot coerce empty String (\"\") to `alpine.model.IConfigProperty$PropertyType` value (but could if coercion was enabled using `CoercionConfig`)\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 92] (through reference chain: org.dependencytrack.model.ProjectProperty[\"propertyType\"])"
}
```

This happens because the `ProjectProperty` struct includes all fields when marshalling to json, including empty fields. The DT api does not allow an empty `propertyType`. 

I thought about adding `omitempty` to all fields except `groupName` and `propertyName` but that might break semantics of the other calls.  Instead, i created a new `ProjectPropertyDelete` struct that only includes the two fields needed for the delete endpoint. 

I also used AI (Claude Opus 4.6) to generate tests for projectProperties, which i reviewed and modified carefully and take full responsibility for. I also noted that the `GetAll` method accepts `PageOptions` but that the API is not paginated at all. As a result totalCount is always returned as 0. This PR does not fix that.   