### PR TITLE
fix: License Struct JSON Tags

### DIFF
--- a/license.go
+++ b/license.go
@@ -10,15 +10,16 @@ import (
 type License struct {
 	UUID                uuid.UUID `json:"uuid"`
 	Name                string    `json:"name"`
-	Text                string    `json:"text"`
-	Template            string    `json:"template"`
-	Header              string    `json:"header"`
-	Comment             string    `json:"comment"`
+	Text                string    `json:"licenseText,omitempty"`
+	Template            string    `json:"standardLicenseTemplate,omitempty"`
+	Header              string    `json:"standardLicenseHeader,omitempty"`
+	Comment             string    `json:"licenseComments,omitempty"`
 	LicenseID           string    `json:"licenseId"`
 	OSIApproved         bool      `json:"isOsiApproved"`
 	FSFLibre            bool      `json:"isFsfLibre"`
 	DeprecatedLicenseID bool      `json:"isDeprecatedLicenseId"`
-	SeeAlso             []string  `json:"seeAlso"`
+	IsCustomLicense     bool      `json:"isCustomLicense"`
+	SeeAlso             []string  `json:"seeAlso,omitempty"`
 }
 
 type LicenseService struct {

--- a/license.go
+++ b/license.go
@@ -18,7 +18,6 @@ type License struct {
 	OSIApproved         bool      `json:"isOsiApproved"`
 	FSFLibre            bool      `json:"isFsfLibre"`
 	DeprecatedLicenseID bool      `json:"isDeprecatedLicenseId"`
-	IsCustomLicense     bool      `json:"isCustomLicense"`
 	SeeAlso             []string  `json:"seeAlso,omitempty"`
 }
 


### PR DESCRIPTION
JSON Tags within `License` struct were using Java Class field names, as opposed to JSON keys from `@JsonProperty`.

Current API `model`:
  - https://github.com/DependencyTrack/dependency-track/blob/4.14.x/src/main/java/org/dependencytrack/model/License.java#L119

Backwards compatible with when `License` was added in 3.0.0:
- https://github.com/DependencyTrack/dependency-track/blob/3.0.0/src/main/java/org/owasp/dependencytrack/model/License.java#L77

CC:
- https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/198
- https://github.com/DependencyTrack/client-go/pull/58