### PR TITLE
feat: Content Type Header Validation

### DIFF
--- a/bom.go
+++ b/bom.go
@@ -54,16 +54,17 @@ func (bs BOMService) ExportComponent(ctx context.Context, componentUUID uuid.UUI
 		params["format"] = string(format)
 	}
 
-	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/bom/cyclonedx/component/%s", componentUUID), withParams(params))
-	if err != nil {
-		return
-	}
-
+	var acceptContentType string
 	switch format {
 	case BOMFormatJSON:
-		req.Header.Set("Accept", "application/vnd.cyclonedx+json")
+		acceptContentType = "application/vnd.cyclonedx+json"
 	case BOMFormatXML:
-		req.Header.Set("Accept", "application/vnd.cyclonedx+xml")
+		acceptContentType = "application/vnd.cyclonedx+xml"
+	}
+
+	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/bom/cyclonedx/component/%s", componentUUID), withParams(params), withAcceptContentType(acceptContentType))
+	if err != nil {
+		return
 	}
 
 	_, err = bs.client.doRequest(req, &bom)
@@ -79,16 +80,17 @@ func (bs BOMService) ExportProject(ctx context.Context, projectUUID uuid.UUID, f
 		params["variant"] = string(variant)
 	}
 
-	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/bom/cyclonedx/project/%s", projectUUID), withParams(params))
-	if err != nil {
-		return
-	}
-
+	var acceptContentType string
 	switch format {
 	case BOMFormatJSON:
-		req.Header.Set("Accept", "application/vnd.cyclonedx+json")
+		acceptContentType = "application/vnd.cyclonedx+json"
 	case BOMFormatXML:
-		req.Header.Set("Accept", "application/vnd.cyclonedx+xml")
+		acceptContentType = "application/vnd.cyclonedx+xml"
+	}
+
+	req, err := bs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/bom/cyclonedx/project/%s", projectUUID), withParams(params), withAcceptContentType(acceptContentType))
+	if err != nil {
+		return
 	}
 
 	_, err = bs.client.doRequest(req, &bom)

--- a/bom.go
+++ b/bom.go
@@ -59,7 +59,12 @@ func (bs BOMService) ExportComponent(ctx context.Context, componentUUID uuid.UUI
 		return
 	}
 
-	req.Header.Set("Accept", "application/vnd.cyclonedx+json")
+	switch format {
+	case BOMFormatJSON:
+		req.Header.Set("Accept", "application/vnd.cyclonedx+json")
+	case BOMFormatXML:
+		req.Header.Set("Accept", "application/vnd.cyclonedx+xml")
+	}
 
 	_, err = bs.client.doRequest(req, &bom)
 	return
@@ -79,7 +84,12 @@ func (bs BOMService) ExportProject(ctx context.Context, projectUUID uuid.UUID, f
 		return
 	}
 
-	req.Header.Set("Accept", "application/vnd.cyclonedx+json")
+	switch format {
+	case BOMFormatJSON:
+		req.Header.Set("Accept", "application/vnd.cyclonedx+json")
+	case BOMFormatXML:
+		req.Header.Set("Accept", "application/vnd.cyclonedx+xml")
+	}
 
 	_, err = bs.client.doRequest(req, &bom)
 	return

--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -355,7 +354,7 @@ func (c Client) doRequest(req *http.Request, v interface{}) (a apiResponse, err 
 		switch vt := v.(type) {
 		case *string:
 			expectedContentTypes := []string{"text/plain", "application/vnd.cyclonedx+json", "application/vnd.cyclonedx+xml"}
-			if !slices.Contains(expectedContentTypes, contentType) {
+			if !sliceContains(expectedContentTypes, contentType) {
 				err = fmt.Errorf("Expected %s content-type. Received %s.", strings.Join(expectedContentTypes, ", "), contentType)
 				return
 			}

--- a/client.go
+++ b/client.go
@@ -356,7 +356,7 @@ func (c Client) doRequest(req *http.Request, v interface{}) (a apiResponse, err 
 		case *string:
 			expectedContentTypes := []string{"text/plain", "application/vnd.cyclonedx+json", "application/vnd.cyclonedx+xml"}
 			if !sliceContains(expectedContentTypes, contentType) {
-				err = fmt.Errorf("Expected %s content-type. Received %s.", strings.Join(expectedContentTypes, ", "), contentType)
+				err = fmt.Errorf("expected %s content-type, but received %s", strings.Join(expectedContentTypes, ", "), contentType)
 				return
 			}
 			if content, readErr := io.ReadAll(res.Body); readErr == nil {
@@ -367,7 +367,7 @@ func (c Client) doRequest(req *http.Request, v interface{}) (a apiResponse, err 
 			}
 		default:
 			if contentType != "application/json" {
-				err = fmt.Errorf("Expected application/json content-type. Received %s.", contentType)
+				err = fmt.Errorf("expected application/json content-type, but received %s", contentType)
 				return
 			}
 			err = json.NewDecoder(res.Body).Decode(v)

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -350,8 +351,14 @@ func (c Client) doRequest(req *http.Request, v interface{}) (a apiResponse, err 
 	}
 
 	if v != nil {
+		contentType := res.Header.Get("Content-Type")
 		switch vt := v.(type) {
 		case *string:
+			expectedContentTypes := []string{"text/plain", "application/vnd.cyclonedx+json", "application/vnd.cyclonedx+xml"}
+			if !slices.Contains(expectedContentTypes, contentType) {
+				err = fmt.Errorf("Expected %s content-type. Received %s.", strings.Join(expectedContentTypes, ", "), contentType)
+				return
+			}
 			if content, readErr := io.ReadAll(res.Body); readErr == nil {
 				*vt = strings.TrimSpace(string(content))
 			} else {
@@ -359,6 +366,10 @@ func (c Client) doRequest(req *http.Request, v interface{}) (a apiResponse, err 
 				return
 			}
 		default:
+			if contentType != "application/json" {
+				err = fmt.Errorf("Expected application/json content-type. Received %s.", contentType)
+				return
+			}
 			err = json.NewDecoder(res.Body).Decode(v)
 			if err != nil {
 				return

--- a/client.go
+++ b/client.go
@@ -351,6 +351,7 @@ func (c Client) doRequest(req *http.Request, v interface{}) (a apiResponse, err 
 
 	if v != nil {
 		contentType := res.Header.Get("Content-Type")
+		contentType = strings.SplitN(contentType, ";", 2)[0]
 		switch vt := v.(type) {
 		case *string:
 			expectedContentTypes := []string{"text/plain", "application/vnd.cyclonedx+json", "application/vnd.cyclonedx+xml"}

--- a/user.go
+++ b/user.go
@@ -71,7 +71,7 @@ func (us UserService) ForceChangePassword(ctx context.Context, username, passwor
 	body.Set("newPassword", newPassword)
 	body.Set("confirmPassword", newPassword)
 
-	req, err := us.client.newRequest(ctx, http.MethodPost, "api/v1/user/forceChangePassword", withBody(body))
+	req, err := us.client.newRequest(ctx, http.MethodPost, "api/v1/user/forceChangePassword", withBody(body), withAcceptContentType("text/plain"))
 	if err != nil {
 		return
 	}

--- a/user.go
+++ b/user.go
@@ -50,12 +50,10 @@ func (us UserService) Login(ctx context.Context, username, password string) (tok
 	body.Set("username", username)
 	body.Set("password", password)
 
-	req, err := us.client.newRequest(ctx, http.MethodPost, "api/v1/user/login", withBody(body))
+	req, err := us.client.newRequest(ctx, http.MethodPost, "api/v1/user/login", withBody(body), withAcceptContentType("text/plain"))
 	if err != nil {
 		return
 	}
-
-	req.Header.Set("Accept", "*/*")
 
 	_, err = us.client.doRequest(req, &token)
 	return
@@ -77,8 +75,6 @@ func (us UserService) ForceChangePassword(ctx context.Context, username, passwor
 	if err != nil {
 		return
 	}
-
-	req.Header.Set("Accept", "*/*")
 
 	_, err = us.client.doRequest(req, nil)
 	return

--- a/util.go
+++ b/util.go
@@ -56,3 +56,13 @@ func OptionalBoolOf(value bool) *bool {
 func OptionalBool() *bool {
 	return nil
 }
+
+func sliceContains[S ~[]E, E comparable](haystack S, needle E) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+
+}

--- a/util.go
+++ b/util.go
@@ -57,6 +57,7 @@ func OptionalBool() *bool {
 	return nil
 }
 
+// slices.Contains - with the same signature is Go 1.21+
 func sliceContains[S ~[]E, E comparable](haystack S, needle E) bool {
 	for _, v := range haystack {
 		if v == needle {
@@ -64,5 +65,4 @@ func sliceContains[S ~[]E, E comparable](haystack S, needle E) bool {
 		}
 	}
 	return false
-
 }

--- a/vex.go
+++ b/vex.go
@@ -26,12 +26,10 @@ type vexUploadResponse struct {
 type VEXUploadToken string
 
 func (vs VEXService) ExportCycloneDX(ctx context.Context, projectUUID uuid.UUID) (vex string, err error) {
-	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/vex/cyclonedx/project/%s", projectUUID))
+	req, err := vs.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("api/v1/vex/cyclonedx/project/%s", projectUUID), withAcceptContentType("application/vnd.cyclonedx+json"))
 	if err != nil {
 		return
 	}
-
-	req.Header.Set("Accept", "application/vnd.cyclonedx+json")
 
 	_, err = vs.client.doRequest(req, &vex)
 	return


### PR DESCRIPTION
- fix: `Accept` Header when exporting a BOM for a Component / Project, and requesting `XML` format.
  - https://github.com/DependencyTrack/dependency-track/blob/4.14.2/src/main/java/org/dependencytrack/resources/v1/BomResource.java#L171
  - https://github.com/DependencyTrack/dependency-track/blob/4.14.2/src/main/java/org/dependencytrack/resources/v1/BomResource.java#L260
- feat: Tighten `Accept` Header on `UserService.Login` from `*/*` to `text/plain`.
  - https://github.com/DependencyTrack/dependency-track/blob/4.14.2/src/main/java/org/dependencytrack/resources/v1/UserResource.java#L114
- feat: Check returned `Content-Type` Header against a list of expected possible values, to avoid misleading JSON parse errors from trying to decode unexpected response formats (e.g. HTML) into JSON, e.g. when using a proxy.
  - List based off possible values within OpenAPI schema from API.
  - Omitted `application/octet-stream`, since that is only able to be generated if `download=true`.
    - https://github.com/DependencyTrack/dependency-track/blob/4.14.2/src/main/java/org/dependencytrack/resources/v1/BomResource.java#L199
    - https://github.com/DependencyTrack/dependency-track/blob/4.14.2/src/main/java/org/dependencytrack/resources/v1/VexResource.java#L134
  - Omitted `application/sarif+json`, since that is only able to be generated if `Accept` Header specifies it.
    - `FindingService.GetAll` does not override default of `application/json`.
    -  https://github.com/DependencyTrack/dependency-track/blob/4.14.2/src/main/java/org/dependencytrack/resources/v1/FindingResource.java#L130
- Remove unnecessary `Accept` header being set on `LoginService.ForceChangePassword`, as the API does not return any content on 200 status code.
  - https://github.com/DependencyTrack/dependency-track/blob/4.14.2/src/main/java/org/dependencytrack/resources/v1/UserResource.java#L212 