### PR TITLE
fix: LastBOMImport omitempty

### DIFF
--- a/project.go
+++ b/project.go
@@ -38,7 +38,7 @@ type Project struct {
 	IsLatest           *bool               `json:"isLatest,omitempty"` // Since v4.12.0
 	Metrics            ProjectMetrics      `json:"metrics"`
 	ParentRef          *ParentRef          `json:"parent,omitempty"`
-	LastBOMImport      int                 `json:"lastBomImport"`
+	LastBOMImport      int                 `json:"lastBomImport,omitempty"`
 	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
 	CollectionLogic    *CollectionLogic    `json:"collectionLogic,omitempty"` // Since v4.13.0
 	CollectionTag      *Tag                `json:"collectionTag,omitempty"`   // Since v4.13.0


### PR DESCRIPTION
The current code sends a zero for this field.
This causes to show the unix zero timestamp date on every non-leaf project.
The chances of someone actually wanting to use 0 as a valid value are slim, so I don't think a pointer is necessary, like at the similar bool values. 